### PR TITLE
Change summit CFP link to tracking URL

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -33,7 +33,7 @@ const Banner = () => {
           </div>
           <div className="mt-2 md:mt-0">
             <a 
-              href="https://forms.gle/vM5rigSGfvFTLVVQ7" 
+              href="https://hubs.la/Q03nBrkJ0" 
               className="px-6 py-2 bg-primary hover:bg-primary-dark text-white font-bold rounded-full transform transition-transform duration-300 hover:scale-105 hover:shadow-xl inline-flex items-center group"
             >
               Submit Your Proposal


### PR DESCRIPTION
# Description of change

At request of the Eclipse Foundation, changing the link to the CFP to be a tracking link.

Fixes https://github.com/adoptium/adoptium.net/issues/1067

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [x] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
