### PR TITLE
update macos homebrew instructions

### DIFF
--- a/src/components/InstallTabs/MacOSPanel/index.tsx
+++ b/src/components/InstallTabs/MacOSPanel/index.tsx
@@ -30,16 +30,12 @@ export const PureMacOSPanel = (): JSX.Element => {
         </span>
         <br />
         <span className="install__text__no-select">$</span>
-        <span className="install-text-command">brew tap </span>
-        homebrew/cask-versions
+        <span className="install-text-command">brew install --cask </span>
+        temurin@8
         <br />
         <span className="install__text__no-select">$</span>
         <span className="install-text-command">brew install --cask </span>
-        temurin8
-        <br />
-        <span className="install__text__no-select">$</span>
-        <span className="install-text-command">brew install --cask </span>
-        temurin{mostRecentLts}
+        temurin@{mostRecentLts}
       </ShellBox>
       <br />
       <br />
@@ -51,7 +47,7 @@ export const PureMacOSPanel = (): JSX.Element => {
         <br />
         <span className="install__text__no-select">$</span>
         <span className="install-text-command">brew uninstall --cask </span>
-        temurin
+        temurin@{mostRecentLts}
       </ShellBox>
       <a className="install__docs-button" href="https://docs.brew.sh/Manpage">
         Read documentation

--- a/src/components/InstallTabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -740,9 +740,9 @@ exports[`Tests for InstallTabs component > renders correctly for macOS 1`] = `
               <span
                 class="install-text-command"
               >
-                brew tap 
+                brew install --cask 
               </span>
-              homebrew/cask-versions
+              temurin@8
               <br />
               <span
                 class="install__text__no-select"
@@ -754,19 +754,7 @@ exports[`Tests for InstallTabs component > renders correctly for macOS 1`] = `
               >
                 brew install --cask 
               </span>
-              temurin8
-              <br />
-              <span
-                class="install__text__no-select"
-              >
-                $
-              </span>
-              <span
-                class="install-text-command"
-              >
-                brew install --cask 
-              </span>
-              temurin
+              temurin@
               1
             </code>
           </pre>
@@ -798,7 +786,8 @@ exports[`Tests for InstallTabs component > renders correctly for macOS 1`] = `
               >
                 brew uninstall --cask 
               </span>
-              temurin
+              temurin@
+              1
             </code>
           </pre>
           <a

--- a/src/components/InstallTabs/__tests__/__snapshots__/macos-panel.test.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/macos-panel.test.tsx.snap
@@ -55,9 +55,9 @@ exports[`Tests for MacOSPanel component > renders correctly 1`] = `
         <span
           class="install-text-command"
         >
-          brew tap 
+          brew install --cask 
         </span>
-        homebrew/cask-versions
+        temurin@8
         <br />
         <span
           class="install__text__no-select"
@@ -69,19 +69,7 @@ exports[`Tests for MacOSPanel component > renders correctly 1`] = `
         >
           brew install --cask 
         </span>
-        temurin8
-        <br />
-        <span
-          class="install__text__no-select"
-        >
-          $
-        </span>
-        <span
-          class="install-text-command"
-        >
-          brew install --cask 
-        </span>
-        temurin
+        temurin@
         1
       </code>
     </pre>
@@ -113,7 +101,8 @@ exports[`Tests for MacOSPanel component > renders correctly 1`] = `
         >
           brew uninstall --cask 
         </span>
-        temurin
+        temurin@
+        1
       </code>
     </pre>
     <a


### PR DESCRIPTION
# Description of change

refers the issue #1105 
tap homebrew/cask-versions has been replaced by homebrew/homebrew-cask
temurin version namings in brew has changed

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
