### PR TITLE
reduce overall height on page headers

### DIFF
--- a/src/app/[locale]/[...slug]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/[...slug]/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`AsciidocPage > renders correctly for installation page 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div
@@ -500,19 +500,19 @@ exports[`AsciidocPage > renders correctly for installation page 1`] = `
 exports[`AsciidocPage > renders correctly with English locale 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div
@@ -771,19 +771,19 @@ exports[`AsciidocPage > renders correctly with English locale 1`] = `
 exports[`AsciidocPage > renders correctly with non-English locale 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/adopters/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/adopters/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Adopters page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/become-a-sustainer/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/become-a-sustainer/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`BecomeASustainer page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/business-benefits/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/business-benefits/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Business Benefits page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/docs/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/docs/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Docs page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 m d:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/download/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/download/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Download page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/events/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/events/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Events page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/join/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/join/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Join page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/marketplace/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/marketplace/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Marketplace page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/members/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/members/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Members page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/news/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/__tests__/__snapshots__/page.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`NewsPage > renders news and header when posts exist 1`] = `
 <div>
   <div>
     <div
-      class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+      class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
     >
       <div
         class="w-full relative"
       >
         <div
-          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
         />
       </div>
       <div

--- a/src/app/[locale]/news/author/[author]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/author/[author]/__tests__/__snapshots__/page.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`AuthorNewsPage > renders news and header for author when posts exist 1`
 <div>
   <div>
     <div
-      class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+      class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
     >
       <div
         class="w-full relative"
       >
         <div
-          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
         />
       </div>
       <div

--- a/src/app/[locale]/news/author/[author]/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/author/[author]/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`AuthorNewsPagePaginated > renders news and header for author and page w
 <div>
   <div>
     <div
-      class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+      class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
     >
       <div
         class="w-full relative"
       >
         <div
-          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
         />
       </div>
       <div

--- a/src/app/[locale]/news/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`NewsPage (paginated) > renders news and header for page when posts exis
 <div>
   <div>
     <div
-      class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+      class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
     >
       <div
         class="w-full relative"
       >
         <div
-          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
         />
       </div>
       <div

--- a/src/app/[locale]/news/tag/[tag]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/tag/[tag]/__tests__/__snapshots__/page.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`TagsPage > renders news and header for tag when posts exist 1`] = `
 <div>
   <div>
     <div
-      class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+      class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
     >
       <div
         class="w-full relative"
       >
         <div
-          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
         />
       </div>
       <div

--- a/src/app/[locale]/news/tag/[tag]/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/tag/[tag]/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`TaggedNewsPage > renders news and header for tag and page when posts ex
 <div>
   <div>
     <div
-      class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+      class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
     >
       <div
         class="w-full relative"
       >
         <div
-          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
         />
       </div>
       <div

--- a/src/app/[locale]/slack/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/slack/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Slack page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/support-us/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/support-us/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Support Us page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/supported-platforms/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/supported-platforms/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Supported Platforms page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/sustainers/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/sustainers/__tests__/__snapshots__/page.test.tsx.snap
@@ -19,19 +19,19 @@ exports[`Sustainers page > renders correctly 1`] = `
       />
     </div>
     <div
-      class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+      class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
     >
       <div
         class="w-full relative"
       >
         <div
-          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
         />
       </div>
       <div

--- a/src/app/[locale]/temurin/nightly/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/temurin/nightly/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`TemurinNightly page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/temurin/release-notes/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/temurin/release-notes/__tests__/__snapshots__/page.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`TemurinPage > renders the release notes page with header and content 1`
 <div>
   <div>
     <div
-      class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+      class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
     >
       <div
         class="w-full relative"
       >
         <div
-          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
         />
         <div
-          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+          class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
         />
       </div>
       <div

--- a/src/app/[locale]/temurin/releases/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/temurin/releases/__tests__/__snapshots__/page.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`TemurinReleases page > renders correctly 1`] = `
 <div>
   <div
-    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+    class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
   >
     <div
       class="w-full relative"
     >
       <div
-        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
       />
       <div
-        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
       />
     </div>
     <div

--- a/src/app/[locale]/temurin/releases/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/temurin/releases/__tests__/__snapshots__/page.test.tsx.snap
@@ -109,13 +109,13 @@ exports[`TemurinReleases page > renders correctly 1`] = `
       </div>
     </section>
     <section
-      class="py-8"
+      class="py-4"
     >
       <div
-        class="space-y-8"
+        class="space-y-4"
       >
         <div
-          class="flex justify-between border flex-wrap border-[#554772] rounded-[24px] !bg-[#200E46] items-start p-6 lg:p-8 animate-pulse"
+          class="flex justify-between border flex-wrap border-[#554772] rounded-[16px] !bg-[#200E46] items-start p-4 lg:p-5 animate-pulse"
         >
           <div
             class="w-full lg:w-[45%] flex flex-col"
@@ -124,55 +124,55 @@ exports[`TemurinReleases page > renders correctly 1`] = `
               class="_animatedPlaceholder_283780"
             >
               <div
-                class="p-6 bg-[#2B1A4F] flex flex-col rounded-[24px] gap-6"
+                class="p-4 bg-[#2B1A4F] flex flex-col rounded-[16px] gap-4"
               >
                 <div
                   class="flex justify-between items-center"
                 >
                   <div
-                    class="flex gap-4 justify-start items-center"
+                    class="flex gap-3 justify-start items-center"
                   >
                     <div
-                      class="w-8 h-8 bg-gray-600 rounded-full animate-pulse"
+                      class="w-6 h-6 bg-gray-600 rounded-full animate-pulse"
                     />
                     <div
-                      class="h-6 bg-gray-600 rounded w-24 animate-pulse"
+                      class="h-5 bg-gray-600 rounded w-20 animate-pulse"
                     />
                   </div>
                   <div
-                    class="flex gap-4"
+                    class="flex gap-3"
                   >
                     <div
-                      class="h-6 bg-gray-600 rounded w-16 animate-pulse"
+                      class="h-5 bg-gray-600 rounded w-14 animate-pulse"
                     />
                   </div>
                 </div>
                 <div
-                  class="h-12 bg-gray-600 rounded-full animate-pulse"
+                  class="h-8 bg-gray-600 rounded-full animate-pulse"
                 />
               </div>
             </div>
           </div>
           <div
-            class="flex flex-col w-full lg:w-[50%] mt-8 lg:mt-0"
+            class="flex flex-col w-full lg:w-[50%] mt-6 lg:mt-0"
           >
             <div
-              class="h-6 bg-gray-600 rounded w-48 mb-6 animate-pulse"
+              class="h-5 bg-gray-600 rounded w-48 mb-4 animate-pulse"
             />
             <div
-              class="space-y-4"
+              class="space-y-3"
             >
               <div
-                class="h-16 bg-gray-600 rounded-xl animate-pulse"
+                class="h-12 bg-gray-600 rounded-xl animate-pulse"
               />
               <div
-                class="h-16 bg-gray-600 rounded-xl animate-pulse"
+                class="h-12 bg-gray-600 rounded-xl animate-pulse"
               />
             </div>
           </div>
         </div>
         <div
-          class="flex justify-between border flex-wrap border-[#554772] rounded-[24px] !bg-[#200E46] items-start p-6 lg:p-8 animate-pulse"
+          class="flex justify-between border flex-wrap border-[#554772] rounded-[16px] !bg-[#200E46] items-start p-4 lg:p-5 animate-pulse"
         >
           <div
             class="w-full lg:w-[45%] flex flex-col"
@@ -181,55 +181,55 @@ exports[`TemurinReleases page > renders correctly 1`] = `
               class="_animatedPlaceholder_283780"
             >
               <div
-                class="p-6 bg-[#2B1A4F] flex flex-col rounded-[24px] gap-6"
+                class="p-4 bg-[#2B1A4F] flex flex-col rounded-[16px] gap-4"
               >
                 <div
                   class="flex justify-between items-center"
                 >
                   <div
-                    class="flex gap-4 justify-start items-center"
+                    class="flex gap-3 justify-start items-center"
                   >
                     <div
-                      class="w-8 h-8 bg-gray-600 rounded-full animate-pulse"
+                      class="w-6 h-6 bg-gray-600 rounded-full animate-pulse"
                     />
                     <div
-                      class="h-6 bg-gray-600 rounded w-24 animate-pulse"
+                      class="h-5 bg-gray-600 rounded w-20 animate-pulse"
                     />
                   </div>
                   <div
-                    class="flex gap-4"
+                    class="flex gap-3"
                   >
                     <div
-                      class="h-6 bg-gray-600 rounded w-16 animate-pulse"
+                      class="h-5 bg-gray-600 rounded w-14 animate-pulse"
                     />
                   </div>
                 </div>
                 <div
-                  class="h-12 bg-gray-600 rounded-full animate-pulse"
+                  class="h-8 bg-gray-600 rounded-full animate-pulse"
                 />
               </div>
             </div>
           </div>
           <div
-            class="flex flex-col w-full lg:w-[50%] mt-8 lg:mt-0"
+            class="flex flex-col w-full lg:w-[50%] mt-6 lg:mt-0"
           >
             <div
-              class="h-6 bg-gray-600 rounded w-48 mb-6 animate-pulse"
+              class="h-5 bg-gray-600 rounded w-48 mb-4 animate-pulse"
             />
             <div
-              class="space-y-4"
+              class="space-y-3"
             >
               <div
-                class="h-16 bg-gray-600 rounded-xl animate-pulse"
+                class="h-12 bg-gray-600 rounded-xl animate-pulse"
               />
               <div
-                class="h-16 bg-gray-600 rounded-xl animate-pulse"
+                class="h-12 bg-gray-600 rounded-xl animate-pulse"
               />
             </div>
           </div>
         </div>
         <div
-          class="flex justify-between border flex-wrap border-[#554772] rounded-[24px] !bg-[#200E46] items-start p-6 lg:p-8 animate-pulse"
+          class="flex justify-between border flex-wrap border-[#554772] rounded-[16px] !bg-[#200E46] items-start p-4 lg:p-5 animate-pulse"
         >
           <div
             class="w-full lg:w-[45%] flex flex-col"
@@ -238,49 +238,49 @@ exports[`TemurinReleases page > renders correctly 1`] = `
               class="_animatedPlaceholder_283780"
             >
               <div
-                class="p-6 bg-[#2B1A4F] flex flex-col rounded-[24px] gap-6"
+                class="p-4 bg-[#2B1A4F] flex flex-col rounded-[16px] gap-4"
               >
                 <div
                   class="flex justify-between items-center"
                 >
                   <div
-                    class="flex gap-4 justify-start items-center"
+                    class="flex gap-3 justify-start items-center"
                   >
                     <div
-                      class="w-8 h-8 bg-gray-600 rounded-full animate-pulse"
+                      class="w-6 h-6 bg-gray-600 rounded-full animate-pulse"
                     />
                     <div
-                      class="h-6 bg-gray-600 rounded w-24 animate-pulse"
+                      class="h-5 bg-gray-600 rounded w-20 animate-pulse"
                     />
                   </div>
                   <div
-                    class="flex gap-4"
+                    class="flex gap-3"
                   >
                     <div
-                      class="h-6 bg-gray-600 rounded w-16 animate-pulse"
+                      class="h-5 bg-gray-600 rounded w-14 animate-pulse"
                     />
                   </div>
                 </div>
                 <div
-                  class="h-12 bg-gray-600 rounded-full animate-pulse"
+                  class="h-8 bg-gray-600 rounded-full animate-pulse"
                 />
               </div>
             </div>
           </div>
           <div
-            class="flex flex-col w-full lg:w-[50%] mt-8 lg:mt-0"
+            class="flex flex-col w-full lg:w-[50%] mt-6 lg:mt-0"
           >
             <div
-              class="h-6 bg-gray-600 rounded w-48 mb-6 animate-pulse"
+              class="h-5 bg-gray-600 rounded w-48 mb-4 animate-pulse"
             />
             <div
-              class="space-y-4"
+              class="space-y-3"
             >
               <div
-                class="h-16 bg-gray-600 rounded-xl animate-pulse"
+                class="h-12 bg-gray-600 rounded-xl animate-pulse"
               />
               <div
-                class="h-16 bg-gray-600 rounded-xl animate-pulse"
+                class="h-12 bg-gray-600 rounded-xl animate-pulse"
               />
             </div>
           </div>

--- a/src/app/[locale]/what-we-do/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/what-we-do/__tests__/__snapshots__/page.test.tsx.snap
@@ -2,19 +2,19 @@
 
 exports[`WhatWeDo page > renders correctly 1`] = `
 <div
-  class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
+  class="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden"
 >
   <div
     class="w-full relative"
   >
     <div
-      class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+      class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
     />
     <div
-      class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+      class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
     />
     <div
-      class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+      class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
     />
   </div>
   <div

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -9,18 +9,53 @@ const Banner = () => {
   // The following is an example that can be used for future banner alert
   // Comment Out The Above Line ( return null ; ) and uncomment the below
 
-  const [isVisible, setIsVisible] = useState(false);
+  const [isVisible, setIsVisible] = useState(true);
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
 
-  // Animation effect when component mounts
+  // Track when component mounts to prevent hydration issues
   useEffect(() => {
-    setIsVisible(true);
+    setIsMounted(true);
   }, []);
+
+  // Handle banner dismissal
+  const handleDismiss = () => {
+    setIsVisible(false);
+    // Wait for fade out animation to complete before removing from DOM
+    setTimeout(() => {
+      setIsDismissed(true);
+    }, 700);
+  };
+
+  // Don't render if dismissed
+  if (isDismissed) {
+    return null;
+  }
 
   return (
     <div className={`bg-gradient-to-r from-[#0E002A] via-[#240b50] to-[#9a227a] py-5 w-full shadow-lg transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}>
       <div className="container mx-auto px-4">
-        <div className="flex flex-col md:flex-row justify-between items-center">
-          <div className="flex items-center gap-4 mb-3 md:mb-0">
+        <div className="flex flex-col md:flex-row justify-between items-center relative">
+          {/* Close button - only show after mount to prevent hydration issues */}
+          {isMounted && (
+            <button
+              onClick={handleDismiss}
+              className="absolute top-0 right-0 md:top-[-8px] md:right-[-8px] p-2 text-gray-300 hover:text-white transition-colors duration-200 group"
+              aria-label="Dismiss banner"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 group-hover:scale-110 transition-transform duration-200"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+
+          <div className={`flex items-center gap-4 mb-3 md:mb-0 ${isMounted ? 'pr-8' : ''}`}>{/* Only add padding after mount */}
             <div className="transform hover:scale-110 transition-transform duration-300">
               <PinkIcon />
             </div>
@@ -34,8 +69,8 @@ const Banner = () => {
             </div>
           </div>
           <div className="mt-2 md:mt-0">
-            <a 
-              href="https://forms.gle/vM5rigSGfvFTLVVQ7" 
+            <a
+              href="https://forms.gle/vM5rigSGfvFTLVVQ7"
               className="px-6 py-2 bg-primary hover:bg-primary-dark text-white font-bold rounded-full transform transition-transform duration-300 hover:scale-105 hover:shadow-xl inline-flex items-center group"
             >
               Submit Your Proposal
@@ -47,7 +82,7 @@ const Banner = () => {
         </div>
       </div>
     </div>
-  )  
+  )
 }
 
 export default Banner

--- a/src/components/Common/PageHeader/index.tsx
+++ b/src/components/Common/PageHeader/index.tsx
@@ -13,11 +13,11 @@ export default function PageHeader({ title, subtitle, description, className }: 
   }
 
   return (
-    <div className="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden">
+    <div className="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden">
       <div className="w-full relative">
-        <div className="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"></div>
-        <div className="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"></div>
-        <div className="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"></div>
+        <div className="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"></div>
+        <div className="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"></div>
+        <div className="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"></div>
       </div>
 
       <div className="mx-auto max-w-[1048px] w-full px-6 lg:px-0 flex flex-col items-center justify-center">

--- a/src/components/Documentation/Header/index.tsx
+++ b/src/components/Documentation/Header/index.tsx
@@ -4,11 +4,11 @@ import DocumentationSearch from "@/components/Documentation/Search"
 
 const DocumentationHeader: React.FC = () => {
   return (
-    <div className="relative pt-40 pb-16 m d:pb-36 md:pt-60 overflow-hidden">
+    <div className="relative pt-20 pb-8 md:pb-16 md:pt-32 overflow-hidden">
       <div className="w-full relative">
-        <div className="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"></div>
-        <div className="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"></div>
-        <div className="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"></div>
+        <div className="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[71px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"></div>
+        <div className="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[60px] md:top-[195px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"></div>
+        <div className="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[318px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"></div>
       </div>
 
       <div className="mx-auto max-w-[1048px] w-full px-6 lg:px-0 flex flex-col items-center justify-center pb-10">

--- a/src/components/Temurin/Releases/OneClickDownload/index.tsx
+++ b/src/components/Temurin/Releases/OneClickDownload/index.tsx
@@ -137,18 +137,18 @@ const OneClickDownload: React.FC<OneClickDownloadProps> = ({
     })
 
     return (
-        <div className="flex justify-between flex-col md:flex-row w-full items-center gap-8 max-w-[1264px] mx-auto">
+        <div className="flex justify-between flex-col md:flex-row w-full items-center gap-6 max-w-[1264px] mx-auto">
             {/* macOS Download Card */}
-            <div className="p-8 bg-[#200E46] justify-between w-full border rounded-[24px] border-[#564873] h-[264px] flex flex-col transition-all duration-300 ease-in-out hover:border-primary shadow-[0_2px_4px_rgba(255,20,100,0.2)]">
-                <span className="p-6 rounded-full w-fit bg-[#2B1A4F] border border-[#5A4D76]">
-                    <FaApple size={30} />
+            <div className="p-6 bg-[#200E46] justify-between w-full border rounded-[24px] border-[#564873] h-[200px] flex flex-col transition-all duration-300 ease-in-out hover:border-primary shadow-[0_2px_4px_rgba(255,20,100,0.2)]">
+                <span className="p-4 rounded-full w-fit bg-[#2B1A4F] border border-[#5A4D76]">
+                    <FaApple size={24} />
                 </span>
-                <div className="flex justify-between items-center gap-8">
-                    <div className="flex flex-col space-y-2">
-                        <h4 className="text-4xl font-semibold">macOS</h4>
-                        <h5 className="text-base font-normal text-grey">{macOSDisplay}</h5>
+                <div className="flex justify-between items-center gap-6">
+                    <div className="flex flex-col space-y-1">
+                        <h4 className="text-3xl font-semibold">macOS</h4>
+                        <h5 className="text-sm font-normal text-grey">{macOSDisplay}</h5>
                     </div>
-                    <span className="p-3 group cursor-pointer rounded-full w-fit bg-[#2B1A4F] border border-[#5A4D76] hover:border-primary transition-all duration-300 ease-in-out">
+                    <span className="p-2 group cursor-pointer rounded-full w-fit bg-[#2B1A4F] border border-[#5A4D76] hover:border-primary transition-all duration-300 ease-in-out">
                         <Link
                             href={{
                                 pathname: "/download",
@@ -167,23 +167,23 @@ const OneClickDownload: React.FC<OneClickDownloadProps> = ({
                                 vendor: "Adoptium"
                             })}
                         >
-                            <BsDownload size={25} />
+                            <BsDownload size={20} />
                         </Link>
                     </span>
                 </div>
             </div>
 
             {/* Windows Download Card */}
-            <div className="p-8 bg-[#200E46] justify-between w-full border rounded-[24px] border-[#564873] h-[264px] flex flex-col transition-all duration-300 ease-in-out hover:border-primary shadow-[0_2px_4px_rgba(255,20,100,0.2)]">
-                <span className="p-6 rounded-full w-fit bg-[#2B1A4F] border border-[#5A4D76]">
-                    <FaWindows size={30} />
+            <div className="p-6 bg-[#200E46] justify-between w-full border rounded-[24px] border-[#564873] h-[200px] flex flex-col transition-all duration-300 ease-in-out hover:border-primary shadow-[0_2px_4px_rgba(255,20,100,0.2)]">
+                <span className="p-4 rounded-full w-fit bg-[#2B1A4F] border border-[#5A4D76]">
+                    <FaWindows size={24} />
                 </span>
-                <div className="flex justify-between items-center gap-8">
-                    <div className="flex flex-col space-y-2">
-                        <h4 className="text-4xl font-semibold">Windows</h4>
-                        <h5 className="text-base font-normal text-grey">{windowsDisplay}</h5>
+                <div className="flex justify-between items-center gap-6">
+                    <div className="flex flex-col space-y-1">
+                        <h4 className="text-3xl font-semibold">Windows</h4>
+                        <h5 className="text-sm font-normal text-grey">{windowsDisplay}</h5>
                     </div>
-                    <span className="p-3 group cursor-pointer rounded-full w-fit bg-[#2B1A4F] border border-[#5A4D76] hover:border-primary transition-all duration-300 ease-in-out">
+                    <span className="p-2 group cursor-pointer rounded-full w-fit bg-[#2B1A4F] border border-[#5A4D76] hover:border-primary transition-all duration-300 ease-in-out">
                         <Link
                             href={{
                                 pathname: "/download",
@@ -202,7 +202,7 @@ const OneClickDownload: React.FC<OneClickDownloadProps> = ({
                                 vendor: "Adoptium"
                             })}
                         >
-                            <BsDownload size={25} />
+                            <BsDownload size={20} />
                         </Link>
                     </span>
                 </div>

--- a/src/components/Temurin/Releases/ReleaseResults/index.tsx
+++ b/src/components/Temurin/Releases/ReleaseResults/index.tsx
@@ -45,34 +45,34 @@ const ReleaseResults: React.FC<ReleaseResultsProps> = ({
     // Show loading state
     if (isLoading) {
         return (
-            <section className="py-8">
-                <div className="space-y-8">
+            <section className="py-4">
+                <div className="space-y-4">
                     {[1, 2, 3].map((index) => (
                         <div
                             key={index}
-                            className="flex justify-between border flex-wrap border-[#554772] rounded-[24px] !bg-[#200E46] items-start p-6 lg:p-8 animate-pulse"
+                            className="flex justify-between border flex-wrap border-[#554772] rounded-[16px] !bg-[#200E46] items-start p-4 lg:p-5 animate-pulse"
                         >
                             <div className="w-full lg:w-[45%] flex flex-col">
                                 <AnimatedPlaceholder>
-                                    <div className="p-6 bg-[#2B1A4F] flex flex-col rounded-[24px] gap-6">
+                                    <div className="p-4 bg-[#2B1A4F] flex flex-col rounded-[16px] gap-4">
                                         <div className="flex justify-between items-center">
-                                            <div className="flex gap-4 justify-start items-center">
-                                                <div className="w-8 h-8 bg-gray-600 rounded-full animate-pulse"></div>
-                                                <div className="h-6 bg-gray-600 rounded w-24 animate-pulse"></div>
+                                            <div className="flex gap-3 justify-start items-center">
+                                                <div className="w-6 h-6 bg-gray-600 rounded-full animate-pulse"></div>
+                                                <div className="h-5 bg-gray-600 rounded w-20 animate-pulse"></div>
                                             </div>
-                                            <div className="flex gap-4">
-                                                <div className="h-6 bg-gray-600 rounded w-16 animate-pulse"></div>
+                                            <div className="flex gap-3">
+                                                <div className="h-5 bg-gray-600 rounded w-14 animate-pulse"></div>
                                             </div>
                                         </div>
-                                        <div className="h-12 bg-gray-600 rounded-full animate-pulse"></div>
+                                        <div className="h-8 bg-gray-600 rounded-full animate-pulse"></div>
                                     </div>
                                 </AnimatedPlaceholder>
                             </div>
-                            <div className="flex flex-col w-full lg:w-[50%] mt-8 lg:mt-0">
-                                <div className="h-6 bg-gray-600 rounded w-48 mb-6 animate-pulse"></div>
-                                <div className="space-y-4">
-                                    <div className="h-16 bg-gray-600 rounded-xl animate-pulse"></div>
-                                    <div className="h-16 bg-gray-600 rounded-xl animate-pulse"></div>
+                            <div className="flex flex-col w-full lg:w-[50%] mt-6 lg:mt-0">
+                                <div className="h-5 bg-gray-600 rounded w-48 mb-4 animate-pulse"></div>
+                                <div className="space-y-3">
+                                    <div className="h-12 bg-gray-600 rounded-xl animate-pulse"></div>
+                                    <div className="h-12 bg-gray-600 rounded-xl animate-pulse"></div>
                                 </div>
                             </div>
                         </div>
@@ -158,10 +158,26 @@ const ReleaseResults: React.FC<ReleaseResultsProps> = ({
         return selectedPackageTypes[key] || 'jdk';
     };
 
+    // Define the preferred order for OS display
+    const osOrder = ['linux', 'windows', 'mac', 'alpine-linux', 'aix', 'solaris'];
+
+    // Sort the OS entries according to the preferred order
+    const sortedOSEntries = Object.entries(groupedReleases).sort(([osA], [osB]) => {
+        const indexA = osOrder.indexOf(osA);
+        const indexB = osOrder.indexOf(osB);
+
+        // If OS not in order list, put it at the end
+        if (indexA === -1 && indexB === -1) return 0;
+        if (indexA === -1) return 1;
+        if (indexB === -1) return -1;
+
+        return indexA - indexB;
+    });
+
     return (
-        <section className="py-8">
-            <div className="space-y-8">
-                {Object.entries(groupedReleases).map(([os, architectures]) => {
+        <section className="py-4">
+            <div className="space-y-4">
+                {sortedOSEntries.map(([os, architectures]) => {
                     const IconComponent = osIcons[os as keyof typeof osIcons] || FcLinux;
                     const architectureList = Object.keys(architectures);
 
@@ -172,11 +188,11 @@ const ReleaseResults: React.FC<ReleaseResultsProps> = ({
                     return (
                         <div
                             key={os}
-                            className="flex justify-between border flex-wrap border-[#554772] rounded-[24px] !bg-[#200E46] items-start p-6 lg:p-8"
+                            className="flex justify-between border flex-wrap border-[#554772] rounded-[24px] !bg-[#200E46] items-start p-4 lg:p-6"
                         >
                             <div className="w-full lg:w-[45%] flex flex-col">
                                 <div>
-                                    <div className="p-6 bg-[#2B1A4F] flex flex-col rounded-[24px] gap-6">
+                                    <div className="p-4 bg-[#2B1A4F] flex flex-col rounded-[24px] gap-4">
                                         <div className="flex justify-between items-center">
                                             <div className="flex gap-4 justify-start items-center">
                                                 <IconComponent size={30} />
@@ -192,7 +208,7 @@ const ReleaseResults: React.FC<ReleaseResultsProps> = ({
                                                         key={arch}
                                                         onClick={() => handleArchSelection(os, arch)}
                                                     >
-                                                        <span className={`py-3 w-full text-base font-normal leading-6 
+                                                        <span className={`py-2 w-full text-base font-normal leading-6 
                               outline-hidden cursor-pointer transition-all duration-200 ease-in-out ${selectedArch === arch
                                                                 ? "border-primary border-b-[2px] text-white"
                                                                 : "text-[#8a809e] border-transparent border-b"
@@ -206,7 +222,7 @@ const ReleaseResults: React.FC<ReleaseResultsProps> = ({
                                         </div>
 
                                         {/* Package type selector buttons */}
-                                        <div className="flex gap-2 mt-2">
+                                        <div className="flex gap-2 mt-1">
                                             <button
                                                 className={`px-4 py-2 text-sm font-medium rounded-full border transition-colors ${getPackageType(os, selectedArch) === "jdk"
                                                     ? "border-[#FF1464] text-[#FF1464] bg-[#2B1A4F]"


### PR DESCRIPTION
# Description of change

We've had a fair number of people complain about the whitespace in the page headers. This PR reduces it to make the pages more compact and faster to scroll through. This change also generally reduces whitepace on the Temurin downloads page and changes page ordering to show Primary platforms above secondary ones

**before:**
<img width="1710" alt="Screenshot 2025-07-01 at 09 33 43" src="https://github.com/user-attachments/assets/f9cc28c7-bd42-4c1d-b097-49d49a451fd9" />

**after:**
<img width="1702" alt="Screenshot 2025-07-01 at 09 34 15" src="https://github.com/user-attachments/assets/8fab6920-d7d0-4cac-a2ca-687192778aec" />


## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
