### PR TITLE
fix: show Today when daysago is 0

### DIFF
--- a/src/components/Announcements/TabContent.tsx
+++ b/src/components/Announcements/TabContent.tsx
@@ -28,6 +28,24 @@ interface TabContentProps {
 
 const TabContent: React.FC<TabContentProps> = ({ posts, isEvents = false }) => {
     const locale = useLocale();
+
+    const formatTimeAgo = (date: string): string => {
+        const daysAgo = Math.floor((new Date().getTime() - new Date(date).getTime()) / (1000 * 60 * 60 * 24));
+
+        switch (true) {
+            case daysAgo === 0:
+                return 'Today';
+            case daysAgo === 1:
+                return '1 day ago';
+            case daysAgo < 7:
+                return `${daysAgo} days ago`;
+            case daysAgo < 14:
+                return '1 week ago';
+            default:
+                const weeksAgo = Math.floor(daysAgo / 7);
+                return `${weeksAgo} weeks ago`;
+        }
+    };
     if (isEvents) {
         return (
             <article>
@@ -80,15 +98,7 @@ const TabContent: React.FC<TabContentProps> = ({ posts, isEvents = false }) => {
                             <a href={link} target="_blank" rel="noopener noreferrer">
                                 <div className="text-[#c4bfce]">
                                     <p className="text-[12px] leading-[133.333%] text-lightgrey mb-0">
-                                        {(() => {
-                                            const daysAgo = Math.floor((new Date().getTime() - new Date(date).getTime()) / (1000 * 60 * 60 * 24));
-                                            if (daysAgo < 7) {
-                                                return daysAgo === 1 ? `1 day ago` : `${daysAgo} days ago`;
-                                            } else {
-                                                const weeksAgo = Math.floor(daysAgo / 7);
-                                                return weeksAgo === 1 ? `1 week ago` : `${weeksAgo} weeks ago`;
-                                            }
-                                        })()}
+                                        {formatTimeAgo(date)}
                                     </p>
                                     <h3 className="text-[20px] leading-[140%] text-white mb-4">
                                         {title}
@@ -102,15 +112,7 @@ const TabContent: React.FC<TabContentProps> = ({ posts, isEvents = false }) => {
                             <Link href={link}>
                                 <div className="text-[#c4bfce]">
                                     <p className="text-[12px] leading-[133.333%] text-lightgrey mb-0">
-                                        {(() => {
-                                            const daysAgo = Math.floor((new Date().getTime() - new Date(date).getTime()) / (1000 * 60 * 60 * 24));
-                                            if (daysAgo < 7) {
-                                                return daysAgo === 1 ? `1 day ago` : `${daysAgo} days ago`;
-                                            } else {
-                                                const weeksAgo = Math.floor(daysAgo / 7);
-                                                return weeksAgo === 1 ? `1 week ago` : `${weeksAgo} weeks ago`;
-                                            }
-                                        })()}
+                                        {formatTimeAgo(date)}
                                     </p>
                                     <h3 className="text-[20px] leading-[140%] text-white mb-4">
                                         {title}


### PR DESCRIPTION
# Description of change

Spotted that right now we show 0 days ago which is wrong

<img width="456" alt="Screenshot 2025-07-01 at 14 26 50" src="https://github.com/user-attachments/assets/ea1ba71e-4c9f-4cc3-b3ef-270798e01667" />

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
