### PR TITLE
README: update Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adoptium.net (Next.js)
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/17e64afa-e88c-45da-9367-db893a423b6f/deploy-status)](https://app.netlify.com/projects/adoptium-next/deploys)
-[![codecov](https://codecov.io/gh/adoptium/adoptium.net-next/branch/main/graph/badge.svg?token=XGJMJVT8BA)](https://codecov.io/gh/adoptium/adoptium.net-next) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/adoptium/adoptium.net-next/badge)](https://api.securityscorecards.dev/projects/github.com/adoptium/adoptium.net-next)
+[![codecov](https://codecov.io/gh/adoptium/adoptium.net/branch/main/graph/badge.svg?token=XGJMJVT8BA)](https://codecov.io/gh/adoptium/adoptium.net) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/adoptium/adoptium.net/badge)](https://api.securityscorecards.dev/projects/github.com/adoptium/adoptium.net)
 
 This repository contains the source code of the [adoptium.net](https://adoptium.net) site (written in Next.js).
 


### PR DESCRIPTION
# Description of change

Now that the repo has been renamed the badge URL is incorrect

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
