### PR TITLE
Updated page for JMC 9.1.1

### DIFF
--- a/content/asciidoc-pages/jmc/index.adoc
+++ b/content/asciidoc-pages/jmc/index.adoc
@@ -1,7 +1,7 @@
 = Eclipse Mission Control
 :page-authors: reinhapa, thegreystone, gdams, karianna, jiekang, hendrikebbers, ggam, xavierfacq
-:stable: 8.3.0
-:snapshot: 9.0.0
+:stable: 9.1.1
+:snapshot: 10.0.0-SNAPSHOT
 
 Eclipse Mission Control is a low-overhead profiling and diagnostics tools
 suite for the JVM.
@@ -25,6 +25,9 @@ https://github.com/thegreystone/jmc-tutorial[Marcus Hirt’s tutorial].
 
 |Linux |{stable}
 |https://github.com/adoptium/jmc-build/releases/download/{stable}/org.openjdk.jmc-{stable}-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-{stable}-linux.gtk.x86_64.tar.gz]
+
+|Linux (aarch64)|{stable}
+|https://github.com/adoptium/jmc-build/releases/download/{stable}/org.openjdk.jmc-{stable}-linux.gtk.aarch64.tar.gz[org.openjdk.jmc-{stable}-linux.gtk.aarch64.tar.gz]
 |=======================================================================
 
 == Preview Eclipse Mission Control {snapshot} (early access)
@@ -32,20 +35,20 @@ https://github.com/thegreystone/jmc-tutorial[Marcus Hirt’s tutorial].
 [width="100%",cols="15%,25%,70%",options="header"]
 |=======================================================================
 |System |Version |Download
-|Windows |{snapshot}-SNAPSHOT
-|https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-win32.win32.x86_64.zip[org.openjdk.jmc-{snapshot}-SNAPSHOT-win32.win32.x86_64.zip]
+|Windows |{snapshot}
+|https://github.com/adoptium/jmc-build/releases/download/{snapshot}/org.openjdk.jmc-{snapshot}-win32.win32.x86_64.zip[org.openjdk.jmc-{snapshot}-win32.win32.x86_64.zip]
 
-|macOS (x86_64) |{snapshot}-SNAPSHOT
-|https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.x86_64.tar.gz]
+|macOS (x86_64) |{snapshot}
+|https://github.com/adoptium/jmc-build/releases/download/{snapshot}/org.openjdk.jmc-{snapshot}-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-{snapshot}-macosx.cocoa.x86_64.tar.gz]
 
-|macOS (aarch_64) |{snapshot}-SNAPSHOT
-|https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.aarch64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.aarch_64.tar.gz]
+|macOS (aarch_64) |{snapshot}
+|https://github.com/adoptium/jmc-build/releases/download/{snapshot}/org.openjdk.jmc-{snapshot}-macosx.cocoa.aarch64.tar.gz[org.openjdk.jmc-{snapshot}-macosx.cocoa.aarch_64.tar.gz]
 
-|Linux (x86_64)|{snapshot}-SNAPSHOT
-|https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.x86_64.tar.gz]
+|Linux (x86_64)|{snapshot}
+|https://github.com/adoptium/jmc-build/releases/download/{snapshot}/org.openjdk.jmc-{snapshot}-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-{snapshot}-linux.gtk.x86_64.tar.gz]
 
-|Linux (aarch64)|{snapshot}-SNAPSHOT
-|https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.aarch64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.aarch64.tar.gz]
+|Linux (aarch64)|{snapshot}
+|https://github.com/adoptium/jmc-build/releases/download/{snapshot}/org.openjdk.jmc-{snapshot}-linux.gtk.aarch64.tar.gz[org.openjdk.jmc-{snapshot}-linux.gtk.aarch64.tar.gz]
 
 |=======================================================================
 
@@ -67,68 +70,10 @@ the Eclipse IDE:
 |{stable}
 |https://github.com/adoptium/jmc-build/releases/download/{stable}/org.openjdk.jmc.updatesite.ide-{stable}.zip[org.openjdk.jmc.updatesite.ide-{stable}.zip]
 
-|{snapshot}-SNAPSHOT
-|https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc.updatesite.ide-{snapshot}-SNAPSHOT.zip[org.openjdk.jmc.updatesite.ide-{snapshot}-SNAPSHOT.zip]
+|{snapshot}
+|https://github.com/adoptium/jmc-build/releases/download/{snapshot}/org.openjdk.jmc.updatesite.ide-{snapshot}.zip[org.openjdk.jmc.updatesite.ide-{snapshot}.zip]
 |=======================================================================
 
 == Older Releases
 
-=== Final Eclipse Mission Control 8.3.0
-
-[cols="20%,20%,70%",options="header"]
-|=======================================================================
-|System |Version |Download
-|Windows |8.3.0
-|https://github.com/adoptium/jmc-build/releases/download/8.3.0/org.openjdk.jmc-8.3.0-win32.win32.x86_64.zip[org.openjdk.jmc-8.3.0-win32.win32.x86_64.zip]
-
-|macOS |8.3.0
-|https://github.com/adoptium/jmc-build/releases/download/8.3.0/org.openjdk.jmc-8.3.0-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-8.3.0-macosx.cocoa.x86_64.tar.gz]
-
-|Linux |8.3.0
-|https://github.com/adoptium/jmc-build/releases/download/8.3.0/org.openjdk.jmc-8.3.0-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-8.3.0-linux.gtk.x86_64.tar.gz]
-|=======================================================================
-
-=== Final Eclipse Mission Control 8.1.1
-
-[cols="20%,20%,70%",options="header"]
-|=======================================================================
-|System |Version |Download
-|Windows |8.1.1
-|https://github.com/adoptium/jmc-build/releases/download/8.1.1/org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip[org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip]
-
-|macOS |8.1.1
-|https://github.com/adoptium/jmc-build/releases/download/8.1.1/org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz]
-
-|Linux |8.1.1
-|https://github.com/adoptium/jmc-build/releases/download/8.1.1/org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz]
-|=======================================================================
-
-=== Final Eclipse Mission Control 8.1.0
-
-[cols="20%,20%,70%",options="header"]
-|=======================================================================
-|System |Version |Download
-|Windows |8.1.0
-|https://github.com/adoptium/jmc-build/releases/download/8.1.0/org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip[org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip]
-
-|macOS |8.1.0
-|https://github.com/adoptium/jmc-build/releases/download/8.1.0/org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz]
-
-|Linux |8.1.0
-|https://github.com/adoptium/jmc-build/releases/download/8.1.0/org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz]
-|=======================================================================
-
-=== Final Eclipse Mission Control 8.0.0
-
-[cols="20%,20%,70%",options="header"]
-|=======================================================================
-|System |Version |Download
-|Windows |8.0.0
-|https://github.com/adoptium/jmc-build/releases/download/8.0.0/org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip[org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip]
-
-|macOS |8.0.0
-|https://github.com/adoptium/jmc-build/releases/download/8.0.0/org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz]
-
-|Linux |8.0.0
-|https://github.com/adoptium/jmc-build/releases/download/8.0.0/org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz]
-|=======================================================================
+include::old-releases.adoc[]

--- a/content/asciidoc-pages/jmc/old-releases.adoc
+++ b/content/asciidoc-pages/jmc/old-releases.adoc
@@ -1,0 +1,115 @@
+:page-authors: reinhapa, thegreystone, gdams, karianna, jiekang, hendrikebbers, ggam, xavierfacq
+
+=== Eclipse Mission Control 9.1.0
+
+[cols="20%,20%,70%",options="header"]
+|=======================================================================
+|System |Version |Download
+|Windows |9.1.0
+|https://github.com/adoptium/jmc-build/releases/download/9.1.0/org.openjdk.jmc-9.1.0-win32.win32.x86_64.zip[org.openjdk.jmc-9.1.0-win32.win32.x86_64.zip]
+
+|macOS |9.1.0
+|https://github.com/adoptium/jmc-build/releases/download/9.1.0/org.openjdk.jmc-9.1.0-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-9.1.0-macosx.cocoa.x86_64.tar.gz]
+
+|Linux |9.1.0
+|https://github.com/adoptium/jmc-build/releases/download/9.1.0/org.openjdk.jmc-9.1.0-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-9.1.0-linux.gtk.x86_64.tar.gz]
+
+|Linux (aarch64)|9.1.0
+|https://github.com/adoptium/jmc-build/releases/download/9.1.0/org.openjdk.jmc-9.1.0-linux.gtk.aarch64.tar.gz[org.openjdk.jmc-9.1.0-linux.gtk.aarch64.tar.gz]
+|=======================================================================
+
+=== Eclipse Mission Control 9.0.0
+
+[cols="20%,20%,70%",options="header"]
+|=======================================================================
+|System |Version |Download
+|Windows |9.0.0
+|https://github.com/adoptium/jmc-build/releases/download/9.0.0/org.openjdk.jmc-9.0.0-win32.win32.x86_64.zip[org.openjdk.jmc-9.0.0-win32.win32.x86_64.zip]
+
+|macOS |9.0.0
+|https://github.com/adoptium/jmc-build/releases/download/9.0.0/org.openjdk.jmc-9.0.0-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-9.0.0-macosx.cocoa.x86_64.tar.gz]
+
+|Linux |9.0.0
+|https://github.com/adoptium/jmc-build/releases/download/9.0.0/org.openjdk.jmc-9.0.0-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-9.0.0-linux.gtk.x86_64.tar.gz]
+
+|Linux (aarch64)|9.0.0
+|https://github.com/adoptium/jmc-build/releases/download/9.0.0/org.openjdk.jmc-9.0.0-linux.gtk.aarch64.tar.gz[org.openjdk.jmc-9.0.0-linux.gtk.aarch64.tar.gz]
+|=======================================================================
+
+=== Eclipse Mission Control 8.3.0
+
+[cols="20%,20%,70%",options="header"]
+|=======================================================================
+|System |Version |Download
+|Windows |8.3.0
+|https://github.com/adoptium/jmc-build/releases/download/8.3.0/org.openjdk.jmc-8.3.0-win32.win32.x86_64.zip[org.openjdk.jmc-8.3.0-win32.win32.x86_64.zip]
+
+|macOS |8.3.0
+|https://github.com/adoptium/jmc-build/releases/download/8.3.0/org.openjdk.jmc-8.3.0-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-8.3.0-macosx.cocoa.x86_64.tar.gz]
+
+|Linux |8.3.0
+|https://github.com/adoptium/jmc-build/releases/download/8.3.0/org.openjdk.jmc-8.3.0-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-8.3.0-linux.gtk.x86_64.tar.gz]
+
+|Linux (aarch64)|8.3.0
+|https://github.com/adoptium/jmc-build/releases/download/8.3.0/org.openjdk.jmc-8.3.0-linux.gtk.aarch64.tar.gz[org.openjdk.jmc-8.3.0-linux.gtk.aarch64.tar.gz]
+|=======================================================================
+
+=== Eclipse Mission Control 8.2.0
+
+[cols="20%,20%,70%",options="header"]
+|=======================================================================
+|System |Version |Download
+|Windows |8.2.0
+|https://github.com/adoptium/jmc-build/releases/download/8.2.0/org.openjdk.jmc-8.2.0-win32.win32.x86_64.zip[org.openjdk.jmc-8.2.0-win32.win32.x86_64.zip]
+
+|macOS |8.2.0
+|https://github.com/adoptium/jmc-build/releases/download/8.2.0/org.openjdk.jmc-8.2.0-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-8.2.0-macosx.cocoa.x86_64.tar.gz]
+
+|Linux |8.2.0
+|https://github.com/adoptium/jmc-build/releases/download/8.2.0/org.openjdk.jmc-8.2.0-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-8.2.0-linux.gtk.x86_64.tar.gz]
+|=======================================================================
+
+=== Eclipse Mission Control 8.1.1
+
+[cols="20%,20%,70%",options="header"]
+|=======================================================================
+|System |Version |Download
+|Windows |8.1.1
+|https://github.com/adoptium/jmc-build/releases/download/8.1.1/org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip[org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip]
+
+|macOS |8.1.1
+|https://github.com/adoptium/jmc-build/releases/download/8.1.1/org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz]
+
+|Linux |8.1.1
+|https://github.com/adoptium/jmc-build/releases/download/8.1.1/org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz]
+|=======================================================================
+
+=== Eclipse Mission Control 8.1.0
+
+[cols="20%,20%,70%",options="header"]
+|=======================================================================
+|System |Version |Download
+|Windows |8.1.0
+|https://github.com/adoptium/jmc-build/releases/download/8.1.0/org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip[org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip]
+
+|macOS |8.1.0
+|https://github.com/adoptium/jmc-build/releases/download/8.1.0/org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz]
+
+|Linux |8.1.0
+|https://github.com/adoptium/jmc-build/releases/download/8.1.0/org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz]
+|=======================================================================
+
+=== Eclipse Mission Control 8.0.0
+
+[cols="20%,20%,70%",options="header"]
+|=======================================================================
+|System |Version |Download
+|Windows |8.0.0
+|https://github.com/adoptium/jmc-build/releases/download/8.0.0/org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip[org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip]
+
+|macOS |8.0.0
+|https://github.com/adoptium/jmc-build/releases/download/8.0.0/org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz]
+
+|Linux |8.0.0
+|https://github.com/adoptium/jmc-build/releases/download/8.0.0/org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz]
+|=======================================================================


### PR DESCRIPTION
# Description of change

Updated the Mission Control Page for the newly released version 9.1.1. Separated old release into separate file

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run build` passes
- [x] documentation is changed or added (if applicable)
- [x] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
