### PR TITLE
search: add cache-control headers

### DIFF
--- a/src/app/api/news/__tests__/route.test.ts
+++ b/src/app/api/news/__tests__/route.test.ts
@@ -16,7 +16,7 @@ describe("GET /api/news", () => {
     const res = await GET(req);
     expect(res.status).toBe(200);
     expect(res.headers.get("Cache-Control")).toBe(
-      "public, max-age=3600, stale-while-revalidate=60"
+      "public, max-age=14400, stale-while-revalidate=60"
     );
     const data = await res.json();
     expect(data).toBeDefined();

--- a/src/app/api/news/byTag/__tests__/route.test.ts
+++ b/src/app/api/news/byTag/__tests__/route.test.ts
@@ -24,7 +24,7 @@ describe("GET /api/news/byTag", () => {
     const res = await GET(req);
     expect(res.status).toBe(200);
     expect(res.headers.get("Cache-Control")).toBe(
-      "public, max-age=3600, stale-while-revalidate=60"
+      "public, max-age=14400, stale-while-revalidate=60"
     );
     const data = await res.json();
     expect(data).toBeDefined();

--- a/src/app/api/news/byTag/route.ts
+++ b/src/app/api/news/byTag/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
     const news = getNewsByTag(tag, { numPosts, page });
     return Response.json(news, {
       headers: {
-        "Cache-Control": "public, max-age=3600, stale-while-revalidate=60",
+        "Cache-Control": "public, max-age=14400, stale-while-revalidate=60",
       },
     });
   } catch {

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest) {
     const news = await getNews({ numPosts, page, includeEF });
     return Response.json(news, {
       headers: {
-        "Cache-Control": "public, max-age=3600, stale-while-revalidate=60",
+        "Cache-Control": "public, max-age=14400, stale-while-revalidate=60",
       },
     });
   } catch {

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -7,7 +7,13 @@ import {
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url!);
   const query = searchParams.get("q") || "";
-  if (query.length < 2) return NextResponse.json([]);
+  if (query.length < 2) {
+    return NextResponse.json([], {
+      headers: {
+        "Cache-Control": "public, max-age=14400, stale-while-revalidate=60",
+      },
+    });
+  }
 
   const paths = await getAllAsciidocPaths();
   const results = [];
@@ -28,5 +34,9 @@ export async function GET(req: NextRequest) {
       });
     }
   }
-  return NextResponse.json(results);
+  return NextResponse.json(results, {
+    headers: {
+      "Cache-Control": "public, max-age=14400, stale-while-revalidate=60",
+    },
+  });
 }


### PR DESCRIPTION
# Description of change

This should take a significant load of the Netlify functions which run every time someone opens a page. I've also made Cloudflare cahce these more aggresively.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
