### PR TITLE
linux apt install prerequities need to include gpg

### DIFF
--- a/content/asciidoc-pages/installation/linux/index.adoc
+++ b/content/asciidoc-pages/installation/linux/index.adoc
@@ -37,7 +37,7 @@ e.g temurin-17-jdk or temurin-8-jdk
 +
 [source, bash]
 ----
-apt install -y wget apt-transport-https
+apt install -y wget apt-transport-https gpg
 ----
 +
 . Download the Eclipse Adoptium GPG key:


### PR DESCRIPTION
`apt` command for installing the prereqs for setting up the repository is missing `gpg` which is used as part of the repository setup.

Noting that this is already in the Spanish version of the file.

# Description of change

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` and `npm run build` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
