### PR TITLE
Update July 2025 PSU blog with container images updates

### DIFF
--- a/content/blog/eclipse-temurin-8u462-11028-17016-2108-2402-available/index.md
+++ b/content/blog/eclipse-temurin-8u462-11028-17016-2108-2402-available/index.md
@@ -30,3 +30,11 @@ This release contains the following fixes and updates.
 ### Alpine default image now version 3.22
 
 Alpine 3.22 is now the default image when pulling eclipse-temurin Docker images. Previous Alpine versions are still available by specifying a suffix of "-3.21" in Dockerfiles, e.g. `eclipse-temurin:21-alpine-3.21`.
+
+### Ubuntu 20.04 (focal) images are no longer being produced
+
+With Ubuntu 20.04 now out of regular support, we are no longer maintaining container images based on that version
+
+### UBI 10 minimal images are now available
+
+In addition to the ubi9-minimal images which were previously available, we are also publishing images based on ubi10-minimal

--- a/content/blog/eclipse-temurin-8u462-11028-17016-2108-2402-available/index.md
+++ b/content/blog/eclipse-temurin-8u462-11028-17016-2108-2402-available/index.md
@@ -37,4 +37,4 @@ With Ubuntu 20.04 now out of regular support, we are no longer maintaining conta
 
 ### UBI 10 minimal images are now available
 
-In addition to the ubi9-minimal images which were previously available, we are also publishing images based on ubi10-minimal
+In addition to the ubi9-minimal images which were previously available, we are also publishing images based on ubi10-minimal.


### PR DESCRIPTION
# Description of change

Looking at the initial blog we should possibly have not mentioned that the containers images were available, but this will update it with a couple of other updates which were not referenced in the blog but are changes in the upstream PR in this release - the removal of Ubuntu 20.04 (focal fossa) and the addition of UBI10-minimal images.

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
