### PR TITLE
Edit view all in Events page

### DIFF
--- a/src/app/[locale]/events/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/events/__tests__/__snapshots__/page.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`Events page > renders correctly 1`] = `
           rel="noopener noreferrer"
           target="_blank"
         >
-          View all
+          View all Eclipse Foundation events
         </a>
         |
         <a

--- a/src/components/Timeline/__tests__/__snapshots__/timeline.test.tsx.snap
+++ b/src/components/Timeline/__tests__/__snapshots__/timeline.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`TimeLine component > should render correctly with events 1`] = `
         rel="noopener noreferrer"
         target="_blank"
       >
-        View all
+        View all Eclipse Foundation events
       </a>
       |
       <a
@@ -188,7 +188,7 @@ exports[`TimeLine component > should render correctly with no events 1`] = `
         rel="noopener noreferrer"
         target="_blank"
       >
-        View all
+        View all Eclipse Foundation events
       </a>
       |
       <a

--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -113,7 +113,7 @@ const TimeLine = ({ data }: TimeLineProps) => {
                     rel="noopener noreferrer"
                     className="flex items-center gap-3"
                 >
-                    View all
+                    View all Eclipse Foundation events
                 </a>
                 |
                 <a


### PR DESCRIPTION
# Description of change
Renamed the View all to "View all Eclipse Foundation events"
<img width="1909" height="167" alt="Screenshot from 2025-08-11 23-56-33" src="https://github.com/user-attachments/assets/c4c44667-44e4-4895-949d-e7d008b2dfff" />
closes #95 

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
