### PR TITLE
Correct arm32 linux jdk-21+ support

### DIFF
--- a/src/data/supported-platforms.json
+++ b/src/data/supported-platforms.json
@@ -306,8 +306,8 @@
             "8": { "supported": true, "docker": true },
             "11": { "supported": true, "docker": true },
             "17": { "supported": true, "docker": true },
-            "21": { "supported": true, "docker": true },
-            "24": { "supported": true, "docker": true }
+            "21": { "supported": false, "docker": false },
+            "24": { "supported": false, "docker": false }
           }
         },
         {


### PR DESCRIPTION
# Description of change

Temurin no longer builds jdk-21+ for arm32 linux
Fixes: https://github.com/adoptium/temurin-build/issues/3958

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
