### PR TITLE
Add RHEL10/UBI10 as supported. Remove Ubuntu 20.04

### DIFF
--- a/src/data/supported-platforms.json
+++ b/src/data/supported-platforms.json
@@ -145,6 +145,16 @@
           }
         },
         {
+          "name": "RHEL / UBI 10.x",
+          "versions": {
+            "8": { "supported": true, "docker": true },
+            "11": { "supported": true, "docker": true },
+            "17": { "supported": true, "docker": true },
+            "21": { "supported": true, "docker": true },
+            "24": { "supported": true, "docker": true }
+          }
+        },
+        {
           "name": "RHEL / UBI 9.x",
           "versions": {
             "8": { "supported": true, "docker": true },
@@ -203,16 +213,6 @@
             "21": { "supported": true, "docker": true },
             "24": { "supported": true, "docker": true }
           }
-        },
-        {
-          "name": "Ubuntu 20.04",
-          "versions": {
-            "8": { "supported": true, "docker": true },
-            "11": { "supported": true, "docker": true },
-            "17": { "supported": true, "docker": true },
-            "21": { "supported": true, "docker": true },
-            "24": { "supported": true, "docker": true }
-          }
         }
       ]
     },
@@ -228,6 +228,16 @@
             "8": { "supported": false, "docker": false },
             "11": { "supported": false, "docker": false },
             "17": { "supported": false, "docker": false },
+            "21": { "supported": true, "docker": true },
+            "24": { "supported": true, "docker": true }
+          }
+        },
+        {
+          "name": "RHEL / UBI 10.x",
+          "versions": {
+            "8": { "supported": true, "docker": true },
+            "11": { "supported": true, "docker": true },
+            "17": { "supported": true, "docker": true },
             "21": { "supported": true, "docker": true },
             "24": { "supported": true, "docker": true }
           }
@@ -274,16 +284,6 @@
         },
         {
           "name": "Ubuntu 22.04",
-          "versions": {
-            "8": { "supported": true, "docker": true },
-            "11": { "supported": true, "docker": true },
-            "17": { "supported": true, "docker": true },
-            "21": { "supported": true, "docker": true },
-            "24": { "supported": true, "docker": true }
-          }
-        },
-        {
-          "name": "Ubuntu 20.04",
           "versions": {
             "8": { "supported": true, "docker": true },
             "11": { "supported": true, "docker": true },
@@ -319,16 +319,6 @@
             "21": { "supported": false, "docker": false },
             "24": { "supported": false, "docker": false }
           }
-        },
-        {
-          "name": "Ubuntu 20.04",
-          "versions": {
-            "8": { "supported": true, "docker": true },
-            "11": { "supported": true, "docker": true },
-            "17": { "supported": true, "docker": true },
-            "21": { "supported": false, "docker": false },
-            "24": { "supported": false, "docker": false }
-          }
         }
       ]
     },
@@ -338,6 +328,16 @@
         "These builds should work on any distribution with glibc version 2.17 or higher."
       ],
       "distros": [
+        {
+          "name": "RHEL / UBI 10.x",
+          "versions": {
+            "8": { "supported": true, "docker": true },
+            "11": { "supported": true, "docker": true },
+            "17": { "supported": true, "docker": true },
+            "21": { "supported": true, "docker": true },
+            "24": { "supported": true, "docker": true }
+          }
+        },
         {
           "name": "RHEL / UBI 9.x",
           "versions": {
@@ -387,16 +387,6 @@
             "21": { "supported": true, "docker": true },
             "24": { "supported": true, "docker": true }
           }
-        },
-        {
-          "name": "Ubuntu 20.04",
-          "versions": {
-            "8": { "supported": true, "docker": true },
-            "11": { "supported": true, "docker": true },
-            "17": { "supported": true, "docker": true },
-            "21": { "supported": true, "docker": true },
-            "24": { "supported": true, "docker": true }
-          }
         }
       ]
     },
@@ -407,6 +397,16 @@
         "JDK8 on s390x has no JIT so is unsupported."
       ],
       "distros": [
+        {
+          "name": "RHEL / UBI 10.x",
+          "versions": {
+            "8": { "supported": false, "docker": false },
+            "11": { "supported": true, "docker": true },
+            "17": { "supported": true, "docker": true },
+            "21": { "supported": true, "docker": true },
+            "24": { "supported": true, "docker": true }
+          }
+        },
         {
           "name": "RHEL / UBI 9.x",
           "versions": {
@@ -459,16 +459,6 @@
         },
         {
           "name": "Ubuntu 22.04",
-          "versions": {
-            "8": { "supported": false, "docker": false },
-            "11": { "supported": true, "docker": true },
-            "17": { "supported": true, "docker": true },
-            "21": { "supported": true, "docker": true },
-            "24": { "supported": true, "docker": true }
-          }
-        },
-        {
-          "name": "Ubuntu 20.04",
           "versions": {
             "8": { "supported": false, "docker": false },
             "11": { "supported": true, "docker": true },


### PR DESCRIPTION
RHEL10 has undergone testing. Ubuntu 20.04 will still work, but has been mostly removed from our testing set as it is no longer in regular support so should not be included.

# Description of change

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` and `npm run build` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
