### PR TITLE
remove Ubuntu 24.04/s390x as showing supported on JDK8

### DIFF
--- a/src/data/supported-platforms.json
+++ b/src/data/supported-platforms.json
@@ -450,7 +450,7 @@
         {
           "name": "Ubuntu 24.04",
           "versions": {
-            "8": { "supported": true, "docker": true },
+            "8": { "supported": false, "docker": false },
             "11": { "supported": true, "docker": true },
             "17": { "supported": true, "docker": true },
             "21": { "supported": true, "docker": true },


### PR DESCRIPTION
We do not build for s390x on JDK8 due to the absence of a JIT in the hotspot codebase on this platform, but the supported platforms table currently incorrectly lists it as supported. This removes that combination from the supported platform matrix.

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` and `npm run build` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
