### PR TITLE
Update support table end date for JDK version 8

### DIFF
--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -88,6 +88,6 @@
 [.small]#jdk8u462+8#
 | Oct 2025 +
 [.small]#jdk8u472#
-| At least Nov 2026
+| At least Dec 2030
 
 |===


### PR DESCRIPTION
# Description of change

Update the JDK8 support date to at least Dec 2030

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
