### PR TITLE
Fix `supported-platform` trademark symbol in title

### DIFF
--- a/src/app/[locale]/supported-platforms/page.tsx
+++ b/src/app/[locale]/supported-platforms/page.tsx
@@ -4,7 +4,7 @@ import PlatformMatrix from "@/components/Support/PlatformMatrix"
 import ContactUs from "@/components/ContactUs"
 
 export const metadata: Metadata = {
-    title: 'Temurin&trade; Supported Platforms',
+    title: 'Temurin™ Supported Platforms',
     description: 'View the supported platforms for Eclipse Temurin, the high-performance, cross-platform, open-source Java runtime binaries that are enterprise-ready and Java SE TCK-tested.',
 }
 


### PR DESCRIPTION
The ™ symbol was being double-escaped causing it to be rendered incorrectly.

Tested locally:
<img width="411" height="79" alt="image" src="https://github.com/user-attachments/assets/37ff2092-dba7-4361-84c3-eee8315ba5b2" />

Fixes: https://github.com/adoptium/adoptium.net/issues/368