### PR TITLE
[issue-344] Properly redirect blog news urls

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,19 +11,25 @@
     preload'''
 
 [[redirects]]
+  from = "https://blog.adoptium.net/:locale/*"
+  to = "https://adoptium.net/:locale/news/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "https://blog.adoptium.net/*"
   to = "https://adoptium.net/news/:splat"
   status = 301
   force = true
 
 [[redirects]]
-  from = "/blog/*"
-  to = "/news/:splat"
+  from = "/:locale/blog/*"
+  to = "/:locale/news/:splat"
   status = 301
   force = true
 
 [[redirects]]
-  from = "/:locale/blog/*"
+  from = "/blog/*"
   to = "/news/:splat"
   status = 301
   force = true


### PR DESCRIPTION
# Description of change

Try to fix #344 

Analyse of the actual rewrites : 

- https://blog.adoptium.net/ -----> https://blog.adoptium.net/fr
- https://blog.adoptium.net/fr     -----> https://adoptium.net/news/fr
- https://adoptium.net/news/fr    -----> https://adoptium.net/fr/news/fr  --> 404

My suggestion is to treat localized blog URLs first.

# Add this one
[[redirects]]
  from = "https://blog.adoptium.net/:locale/*"
  to = "https://adoptium.net/:locale/news/:splat"
  status = 301
  force = true

# Correct this one and treat before the other one:
[[redirects]]
  from = "/:locale/blog/*"
  to = "/:locale/news/:splat"
  status = 301
  force = true


## Checklist
- [X] `npm test` and `npm run build` passes
