### PR TITLE
DownloadCounter Moved Closer to CTA

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -19,10 +19,10 @@ export default function HomePageClient({
     return (
         <div>
             <HeroSection latestLTS={latestLTS} />
+            <DownloadCounter total={total_downloads} />
             <LogoCarousel />
             <BlockAnnouncement />
             <PowerOfTemurin />
-            <DownloadCounter total={total_downloads} />
             <TemurinFeatures />
             <WGProjects />
             <Testimonials />

--- a/src/components/DownloadCounter/index.tsx
+++ b/src/components/DownloadCounter/index.tsx
@@ -54,17 +54,17 @@ const DownloadCounter = ({ total }: DownloadCounterProps) => {
   }, [animate, endValue, startValue, duration])
 
   return (
-    <div className="bg-purple py-8 lg:py-16" ref={counterRef}>
+    <div className="bg-purple py-8 lg:py-6" ref={counterRef}>
       <div className="mx-auto max-w-[832px] w-full px-6 lg:px-0 flex flex-col items-center justify-center">
-        <h2 className="text-center text-[36px] sm:text-5xl font-semibold leading-[44px] sm:leading-[56px] text-white">
+        <h2 className="text-center text-[24px] sm:text-3xl font-semibold leading-[32px] sm:leading-[40px] text-white">
           {t('title')}
         </h2>
-        <h3 className="text-center text-[64px] lg:text-[104px] leading-[72px] lg:leading-[120px] font-semibold my-8" style={{ color: '#FF1365' }}>
+        <h3 className="text-center text-[40px] lg:text-[64px] leading-[48px] lg:leading-[72px] font-semibold my-4" style={{ color: '#FF1365' }}>
           {count.toLocaleString()}
         </h3>
         <div className="flex items-center gap-4 flex-wrap sm:gap-6 justify-center">
           <span>
-            <DiGithubFull size={70} />
+            <DiGithubFull size={50} />
           </span>
           <p className="text-[16px] font-normal leading-6 text-white mb-0">
             {t('total-download-docker-pulls-ever')}


### PR DESCRIPTION
https://github.com/adoptium/adoptium.net/issues/397

- I've implemented the changes outlined in the issue. Additionally, I adjusted the layout so that the download counter are positioned directly beneath the download button. To achieve better alignment, I slightly reduced the size of the download component. Now, while a user initiates a Temurin download, they'll immediately see the total number of downloads, providing instant credibility and reinforcing trust in the product.
Another implementation of this enhancement is raised under #413

@CarmenDelgadoEclipse @gdams @smlambert Please check, if this PR aligns with your expectation. Happy to make adjustments if needed!

# Description of change
<img width="1900" height="861" alt="image" src="https://github.com/user-attachments/assets/37d4675c-8b77-4261-8147-545b9ff8f911" />


[screen-capture (1).webm](https://github.com/user-attachments/assets/8f1edfe1-0624-4b21-8b41-501149bc5432)



<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run build` passes
- [x] documentation is changed or added (if applicable)
- [x] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
