### PR TITLE
add note to jdk25 release blog about x86-64-v2 removal from UBI10 images

### DIFF
--- a/content/blog/eclipse-temurin-25-available/index.md
+++ b/content/blog/eclipse-temurin-25-available/index.md
@@ -30,3 +30,7 @@ Since we enable JEP 493 for builds later than JDK 24, it's enabled for JDK 25 as
 ### Changes to Windows build toolchain
 
 The Microsoft VS2022 toolchain used for the Windows builds has been upgraded to the latest Visual Studio 2022 version 17.12.12 (C/C++ Compiler version 19.42.34444, MSVC toolset version 14.42.34433).
+
+### UBI container images are now UBI10 only, which removes x86-64-v2 support
+
+JDK25 is the first LTS where the UBI container images are exclusively published with UBI10 and not UBI9. This will impact anyone who is running on an x86-64-v2 system which is [no longer supported by UBI10/RHEL10/CentOS Stream 10](https://access.redhat.com/solutions/7066628). jdk21 and earlier versions will continue to be published with UBI9 images for the foreseeable future.


### PR DESCRIPTION
Update as per PMC discussion since this information is currently missing from the release notes for JDK25.

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
