### PR TITLE
Update glibc version for riscv64. Add JDK17

### DIFF
--- a/src/data/supported-platforms.json
+++ b/src/data/supported-platforms.json
@@ -452,7 +452,7 @@
     {
       "category": "Linux (riscv64)",
       "footnotes": [
-        "These builds should work on any distribution with glibc version 2.31 or higher."
+        "These builds should work on any distribution with glibc version 2.27 or higher."
       ],
       "distros": [
         {
@@ -460,7 +460,7 @@
           "versions": {
             "8": { "supported": false, "docker": false },
             "11": { "supported": false, "docker": false },
-            "17": { "supported": false, "docker": false },
+            "17": { "supported": true, "docker": true },
             "21": { "supported": true, "docker": true },
             "25": { "supported": true, "docker": true }
           }
@@ -470,7 +470,7 @@
           "versions": {
             "8": { "supported": false, "docker": false },
             "11": { "supported": false, "docker": false },
-            "17": { "supported": false, "docker": false },
+            "17": { "supported": true, "docker": false },
             "21": { "supported": true, "docker": false },
             "25": { "supported": true, "docker": false }
           }
@@ -480,7 +480,7 @@
           "versions": {
             "8": { "supported": false, "docker": false },
             "11": { "supported": false, "docker": false },
-            "17": { "supported": false, "docker": false },
+            "17": { "supported": true, "docker": false },
             "21": { "supported": true, "docker": false },
             "25": { "supported": true, "docker": false }
           }


### PR DESCRIPTION
Ref:
- https://github.com/adoptium/infrastructure/issues/4131#issuecomment-3516459609
- https://hub.docker.com/r/riscv64/eclipse-temurin/ which shows the available versions

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
