### PR TITLE
Clarify C runtimes for AIX, add jdk25 as supported

### DIFF
--- a/content/asciidoc-pages/installation/archives/index.adoc
+++ b/content/asciidoc-pages/installation/archives/index.adoc
@@ -113,10 +113,8 @@ available with the compiler or standalone, for
 link:https://www.ibm.com/support/pages/ibm-xl-cc-runtime-aix-131[XLC 13.1]
 for JDK8, and
 link:https://www.ibm.com/support/pages/ibm-xl-cc-runtime-aix-161[XLC 16.1]
-for JDK11, 17 and 21, and 
+for JDK11, 17 and 21, and
 link:https://www.ibm.com/docs/en/openxl-c-and-cpp-aix/17.1.2?topic=reference-open-xl-cc-runtime-environment-filesets[OpenXL 17] (which also requires AIX 7.2 TL5 SP3 or later).
-
-. 
 . Make sure you have downloaded the latest link:/download[AIX binary]
 to a directory that will not move or be deleted, and use Terminal to cd
 into it.

--- a/content/asciidoc-pages/installation/archives/index.adoc
+++ b/content/asciidoc-pages/installation/archives/index.adoc
@@ -110,10 +110,13 @@ java -version
 . The last versions of Eclipse Temurin able to run on AIX 7.1 were 8u362,
 11.0.18 and 17.0.8. Later versions require IBM XL C/C++ runtime package,
 available with the compiler or standalone, for
-link:https://www.ibm.com/support/pages/ibm-xl-cc-runtime-aix-131[AIX 13.1]
+link:https://www.ibm.com/support/pages/ibm-xl-cc-runtime-aix-131[XLC 13.1]
 for JDK8, and
-link:https://www.ibm.com/support/pages/ibm-xl-cc-runtime-aix-161[AIX 16.1]
-for JDK11+. 
+link:https://www.ibm.com/support/pages/ibm-xl-cc-runtime-aix-161[XLC 16.1]
+for JDK11, 17 and 21, and 
+link:https://www.ibm.com/docs/en/openxl-c-and-cpp-aix/17.1.2?topic=reference-open-xl-cc-runtime-environment-filesets[OpenXL 17] (which also requires AIX 7.2 TL5 SP3 or later).
+
+. 
 . Make sure you have downloaded the latest link:/download[AIX binary]
 to a directory that will not move or be deleted, and use Terminal to cd
 into it.

--- a/src/data/supported-platforms.json
+++ b/src/data/supported-platforms.json
@@ -635,7 +635,7 @@
     {
       "category": "AIX (PowerPC 64-bit)",
       "footnotes": [
-        "AIX 7.1 is no longer supported. AIX 7.2 or later is required."
+        "Versions 22 and above require the OpenXL17 runtime to be available. LTS versions 11 through 21 requires the XLC16 runtime and jdk8u requires the XLC13 runtime."
       ],
       "distros": [
         {
@@ -645,7 +645,7 @@
             "11": { "supported": true, "docker": false },
             "17": { "supported": true, "docker": false },
             "21": { "supported": true, "docker": false },
-            "25": { "supported": false, "docker": false }
+            "25": { "supported": true, "docker": false }
           }
         }
       ]

--- a/src/data/supported-platforms.json
+++ b/src/data/supported-platforms.json
@@ -635,7 +635,7 @@
     {
       "category": "AIX (PowerPC 64-bit)",
       "footnotes": [
-        "Versions 22 and above require the OpenXL17 runtime to be available. LTS versions 11 through 21 requires the XLC16 runtime and jdk8u requires the XLC13 runtime."
+        "Temurin versions 22 and above require the OpenXL17 runtime to be available. LTS versions 11 through 21 requires the XLC16 runtime and jdk8u requires the XLC13 runtime."
       ],
       "distros": [
         {


### PR DESCRIPTION
# Description of change

Website has not been updated to say that JDK25 is supported for AIX and is missing the information announced in the [July 2024 release blog post](https://adoptium.net/en-GB/news/2024/07/eclipse-temurin-8u422-11024-1712-2104-2202-available)

We should be able to add AIX 7.3 once we've got that version [fully into the AQA test set](https://github.com/adoptium/infrastructure/issues/3920)

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
