### PR TITLE
Revert "Update Oct25 blog for jdk17 win 32 unavailable msg"

### DIFF
--- a/content/blog/eclipse-temurin-8u472-11029-17017-2109-2501-available/index.md
+++ b/content/blog/eclipse-temurin-8u472-11029-17017-2109-2501-available/index.md
@@ -38,7 +38,3 @@ JDK25 UBI container images are exclusively published with UBI10 and not UBI9. Th
 ### Windows aarch64 unavailable for JDK25
 
 Temurin jdk-25.0.1 for the Windows on Aarch64 platform is currently unavailable. A small number of test failures indicated that there is need to investigate and correct before release. We hope that these issues will be rectified upstream and a release completed in a future cycle.
-
-### Windows x32 unavailable for JDK17
-
-Temurin jdk-17.0.17 for the Windows on x32 platform will be unavailable due to a blocking test issue.


### PR DESCRIPTION
Reverts adoptium/adoptium.net#516

We resolved the test failure, and have now publish jdk17 Win x32