### PR TITLE
Use fake date to avoid pb of build with Banner elements

### DIFF
--- a/src/components/Banner/__test__/index.test.tsx
+++ b/src/components/Banner/__test__/index.test.tsx
@@ -1,13 +1,24 @@
 import React from "react";
 import { render, screen, cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import Banner from "../index";
 
-vi.useFakeTimers();
-
 describe("Banner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.useFakeTimers();
+
+    // Default date for all tests -> 21/12/2012 - This is the end of the world!
+    // NOTE: this is important for accessibility tests
+    const date = Date.UTC(2012, 11, 21, 0, 0, 0, 0);
+    vi.setSystemTime(date);
+  });
+
   afterEach(() => {
     cleanup();
+
+    vi.useRealTimers();
   });
 
   it("renders the banner with heading", () => {

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -47,6 +47,14 @@ const currentBanners: BannerProps[] = [
     startDate: "2025-09-30T23:59:59Z",
     endDate: "2025-11-15T23:59:59Z",
   },
+  {
+    title: "Fake Banner for Testing",
+    description: "This is a fake banner used for testing purposes only.",
+    cta: "Read the Case Study",
+    ctaLink: "https://example.com",
+    startDate: "2012-12-21T00:00:00Z",
+    endDate: "2012-12-21T23:59:59Z",
+  }
 ];
 
 const Banner = () => {

--- a/src/components/BannerMiddle/__test__/index.test.tsx
+++ b/src/components/BannerMiddle/__test__/index.test.tsx
@@ -1,13 +1,26 @@
 import React from "react";
 import { render, screen, cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import BannerMiddle from "../index";
 
 vi.useFakeTimers();
 
 describe("BannerMiddle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.useFakeTimers();
+
+    // Default date for all tests -> 21/12/2012 - This is the end of the world!
+    // NOTE: this is important for accessibility tests
+    const date = Date.UTC(2012, 11, 21, 0, 0, 0, 0);
+    vi.setSystemTime(date);
+  });
+
   afterEach(() => {
     cleanup();
+
+    vi.useRealTimers();
   });
 
   it("renders the banner with heading", () => {


### PR DESCRIPTION
# Description of change

This PR is to fix pb with tests on various banners (Banner & BannerMiddle) depending of date. 
Use a fake date in the past.

## Checklist
- [X] `npm test` and `npm run build` passes
