### PR TITLE
Fix/pb with banner and date

### DIFF
--- a/src/app/[locale]/__tests__/page.test.tsx
+++ b/src/app/[locale]/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { render } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it, vi, beforeEach, afterEach  } from "vitest"
 import { axe } from "vitest-axe"
 import HomePage from "../HomePageClient"
 
@@ -12,6 +12,19 @@ vi.mock("@/components/News/LatestNews", () => {
 })
 
 describe("Index page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default date for all tests -> 21/12/2012 - This is the end of the world!
+    // NOTE: this is important for accessibility tests
+    const date = Date.UTC(2012, 11, 21, 0, 0, 0, 0);
+    vi.useFakeTimers({now: date, shouldAdvanceTime: true});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("renders correctly", () => {
     const { container } = render(<HomePage latestLTS={21} total_downloads={1000000000} />)
     expect(container.firstChild).toMatchSnapshot()

--- a/src/app/[locale]/sitemap/__tests__/page.test.tsx
+++ b/src/app/[locale]/sitemap/__tests__/page.test.tsx
@@ -7,12 +7,18 @@ import { SitemapData } from '@/types/sitemap';
 describe('SitemapClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers();
+
+    // Default date for all tests -> 21/12/2012 - This is the end of the world!
+    // NOTE: this is important for accessibility tests
+    const date = Date.UTC(2012, 11, 21, 0, 0, 0, 0);
+    vi.useFakeTimers({now: date, shouldAdvanceTime: true});
+
     document.body.innerHTML = '';
   });
 
   afterEach(() => {
     vi.useRealTimers();
+
     document.body.innerHTML = '';
   });
 

--- a/src/app/[locale]/temurin/nightly/__tests__/page.test.tsx
+++ b/src/app/[locale]/temurin/nightly/__tests__/page.test.tsx
@@ -15,10 +15,12 @@ const allVersions = [
 
 describe("TemurinNightly page", () => {
   it("renders correctly", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2025-06-13T12:00:00Z"));
+    const date = new Date("2025-06-13T12:00:00Z");
+    vi.useFakeTimers({now: date, shouldAdvanceTime: true});
+
     const { container } = render(<TemurinNightly allVersions={allVersions} latestLTS={21} />)
     expect(container.firstChild).toMatchSnapshot()
+
     vi.useRealTimers();
   })
 

--- a/src/components/Banner/__test__/index.test.tsx
+++ b/src/components/Banner/__test__/index.test.tsx
@@ -7,12 +7,10 @@ describe("Banner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    vi.useFakeTimers();
-
     // Default date for all tests -> 21/12/2012 - This is the end of the world!
     // NOTE: this is important for accessibility tests
     const date = Date.UTC(2012, 11, 21, 0, 0, 0, 0);
-    vi.setSystemTime(date);
+    vi.useFakeTimers({now: date, shouldAdvanceTime: true});
   });
 
   afterEach(() => {

--- a/src/components/Banner/__test__/index.test.tsx
+++ b/src/components/Banner/__test__/index.test.tsx
@@ -1,13 +1,24 @@
 import React from "react";
 import { render, screen, cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import Banner from "../index";
 
-vi.useFakeTimers();
-
 describe("Banner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.useFakeTimers();
+
+    // Default date for all tests -> 21/12/2012 - This is the end of the world!
+    // NOTE: this is important for accessibility tests
+    const date = Date.UTC(2012, 11, 21, 0, 0, 0, 0);
+    vi.setSystemTime(date);
+  });
+
   afterEach(() => {
     cleanup();
+
+    vi.useRealTimers();
   });
 
   it("renders the banner with heading", () => {

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -47,6 +47,14 @@ const currentBanners: BannerProps[] = [
     startDate: "2025-09-30T23:59:59Z",
     endDate: "2025-11-15T23:59:59Z",
   },
+  {
+    title: "Fake Banner for Testing",
+    description: "This is a fake banner used for testing purposes only.",
+    cta: "Read the Case Study",
+    ctaLink: "https://example.com",
+    startDate: "2012-12-21T00:00:00Z",
+    endDate: "2012-12-21T23:59:59Z",
+  }
 ];
 
 const Banner = () => {

--- a/src/components/BannerMiddle/__test__/index.test.tsx
+++ b/src/components/BannerMiddle/__test__/index.test.tsx
@@ -1,13 +1,26 @@
 import React from "react";
 import { render, screen, cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import BannerMiddle from "../index";
 
 vi.useFakeTimers();
 
 describe("BannerMiddle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.useFakeTimers();
+
+    // Default date for all tests -> 21/12/2012 - This is the end of the world!
+    // NOTE: this is important for accessibility tests
+    const date = Date.UTC(2012, 11, 21, 0, 0, 0, 0);
+    vi.setSystemTime(date);
+  });
+
   afterEach(() => {
     cleanup();
+
+    vi.useRealTimers();
   });
 
   it("renders the banner with heading", () => {

--- a/src/components/BannerMiddle/__test__/index.test.tsx
+++ b/src/components/BannerMiddle/__test__/index.test.tsx
@@ -3,18 +3,14 @@ import { render, screen, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import BannerMiddle from "../index";
 
-vi.useFakeTimers();
-
 describe("BannerMiddle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    vi.useFakeTimers();
-
     // Default date for all tests -> 21/12/2012 - This is the end of the world!
     // NOTE: this is important for accessibility tests
     const date = Date.UTC(2012, 11, 21, 0, 0, 0, 0);
-    vi.setSystemTime(date);
+    vi.useFakeTimers({now: date, shouldAdvanceTime: true});
   });
 
   afterEach(() => {


### PR DESCRIPTION
# Description of change
This PR is to fix pb with tests on various banners (Banner & BannerMiddle) depending of date.
Use a fake date in the past.

The problem is that we add a banner with different dates over time, and the tests fail because the dates expire. We need to run the tests with the banner on a specific date in the past to avoid issues.


## Checklist
- [X] `npm test` and `npm run build` passes
