### PR TITLE
feat: Add membership banner

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -20,6 +20,14 @@ type BannerProps = {
 // -------------------------------------------------------
 const currentBanners: BannerProps[] = [
   {
+    title: "Become an Adoptium member",
+    description: "Join the Adoptium Working Group and support the future of open source Java. Explore our membership options and benefits.",
+    cta: "Learn more",
+    ctaLink: "https://adoptium.net/members",
+    startDate: "2025-12-03T00:00:00Z",
+    endDate: "2026-01-11T23:59:59Z",
+  },
+  {
     title: "Help sustain Adoptium this Giving Tuesday",
     description: "Your support helps us maintain the open infrastructure that powers reliable release cycles and secure builds across the Adoptium ecosystem — including Eclipse Temurin.",
     cta: "Become a sponsor today",


### PR DESCRIPTION
Added the “Become an Adoptium member” banner and it is set to appear from 3 December.
- Fixes:#566
<img width="1897" height="871" alt="image" src="https://github.com/user-attachments/assets/6e576b4c-18e3-4064-a891-558c45c0e365" />


## Checklist

- [X] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
