### PR TITLE
[issue-455] Add stats link in other resources

### DIFF
--- a/src/app/[locale]/docs/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/docs/__tests__/__snapshots__/page.test.tsx.snap
@@ -977,6 +977,12 @@ exports[`Docs page > renders correctly 1`] = `
                     >
                       Join Us
                     </a>
+                    <a
+                      class="block px-4 py-3 text-white/80 hover:text-white hover:bg-white/10 rounded-lg my-1 transition-all duration-200"
+                      href="/stats/download"
+                    >
+                      Temurin Download Statistics
+                    </a>
                   </div>
                 </div>
               </div>

--- a/src/app/[locale]/docs/page.tsx
+++ b/src/app/[locale]/docs/page.tsx
@@ -223,6 +223,10 @@ export default function DocumentationPage() {
                                         name: "Join Us",
                                         link: "/join-us",
                                     },
+                                    {
+                                        name: "Temurin Download Statistics",
+                                        link: "/stats/download",
+                                    },
                                 ]}
                             />
                             <DocumentationCard


### PR DESCRIPTION
# Description of change

#455  Add a link to the statistics in the Other Resources page.

## Checklist
- [X] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
