### PR TITLE
[issue-604] Add annoucement for Solaris & Win32

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -29,12 +29,12 @@ type BannerProps = {
 // -------------------------------------------------------
 const currentBanners: BannerProps[] = [
   {
-    title: "Become an Adoptium member",
-    description: "Join the Adoptium Working Group and support the future of open source Java. Explore our membership options and benefits.",
-    cta: "Learn more",
-    ctaLink: "https://adoptium.net/members",
-    startDate: "2025-12-03T00:00:00Z",
-    endDate: "2026-01-11T23:59:59Z",
+    title: "End of Support: Solaris & Windows 32-bit for Eclipse Temurin in 2026",
+    description: "Temurin builds for Solaris and Windows 32-bit will be discontinued in 2026. Review the upcoming changes and share your feedback to help us plan the transition.",
+    cta: "Read the full announcement",
+    ctaLink: "https://adoptium.net/news/2025/12/solaris-win32-removal",
+    startDate: "2025-12-11T00:00:00Z",
+    endDate: "2026-01-06T23:59:59Z",
   },
   {
     title: "Help sustain Adoptium this Giving Tuesday",

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -30,7 +30,7 @@ type BannerProps = {
 const currentBanners: BannerProps[] = [
   {
     title: "End of Support: Solaris & Windows 32-bit for Eclipse Temurin in 2026",
-    description: "Temurin builds for Solaris and Windows 32-bit will be discontinued in 2026. Review the upcoming changes and share your feedback to help us plan the transition.",
+    description: "Temurin builds for Solaris and Windows 32-bit will be discontinued in 2026. Review the upcoming changes and share your feedback.",
     cta: "Read the full announcement",
     ctaLink: "https://adoptium.net/news/2025/12/solaris-win32-removal",
     startDate: "2025-12-11T00:00:00Z",

--- a/src/components/BannerMiddle/index.tsx
+++ b/src/components/BannerMiddle/index.tsx
@@ -18,6 +18,14 @@ type BannerMiddleProps = {
 // -------------------------------------------------------
 const currentAnnouncements: BannerMiddleProps[] = [
   {
+    title: "Become an Adoptium member",
+    description: "Join the Adoptium Working Group and support the future of open source Java. Explore our membership options and benefits.",
+    cta: "Learn more",
+    ctaLink: "https://adoptium.net/members",
+    startDate: "2025-12-03T00:00:00Z",
+    endDate: "2026-01-11T23:59:59Z",
+  },
+  {
     title: "Become a sustainer!",
     description:
       "Join the Eclipse Temurin Sustainer Program to support Eclipse Temurin, the fastest-growing open source JDK. Your support fuels stronger security, faster releases, ready-to-deploy builds, quality testing and community development.",


### PR DESCRIPTION
# Description of change

Changes requested in #604 

- Add the Banner for Solaris/Win 32
- Move the Become an Adoptium member in the Middle Banner  (randomized with other active)


## Checklist
- [X] `npm test` and `npm run build` passes
