### PR TITLE
fix: resolve Next.js Image warnings for aspect ratio, LCP, and sizing

### DIFF
--- a/src/app/[locale]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/__tests__/__snapshots__/page.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`Index page > renders correctly 1`] = `
         <img
           alt="Temurin Logo Background"
           class="object-contain"
+          sizes="1000px"
           src="/images/backgrounds/temurin-hero-img.png"
         />
       </div>
@@ -109,126 +110,126 @@ exports[`Index page > renders correctly 1`] = `
             class="mt-6"
             data-testid="react-slick-mock"
           >
-            <span
-              class="px-4"
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Arm"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-arm-white.svg"
                 style="padding: 1em;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Atlassian"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-atlassian-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Dynatrace"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-dynatrace-white.png"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Mercedes-Benz Tech Innovation GmbH"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-mercedes-benz-white.png"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Michelin"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-michelin-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Microsoft"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-microsoft-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="MongoDB"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-mongodb-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Red Hat"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/Logo-RedHat-A-White-RGB.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Societe Generale"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-societe-generale-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="T-Systems"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-t-systems-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -851,7 +852,7 @@ exports[`Index page > renders correctly 1`] = `
           >
             <img
               alt="Eclipse Temurin® logo"
-              class="w-[140px]"
+              class="w-[140px] h-auto"
               height="70"
               src="/images/projects/temurin-project.svg"
               width="140"
@@ -919,7 +920,7 @@ exports[`Index page > renders correctly 1`] = `
           >
             <img
               alt="Eclipse AQAvit logo"
-              class="w-[140px]"
+              class="w-[140px] h-auto"
               height="70"
               src="/images/projects/aqavit-project.svg"
               width="140"
@@ -987,7 +988,7 @@ exports[`Index page > renders correctly 1`] = `
           >
             <img
               alt="Eclipse Mission Control logo"
-              class="w-[140px]"
+              class="w-[140px] h-auto"
               height="70"
               src="/images/projects/mc-project.svg"
               width="140"
@@ -1207,7 +1208,7 @@ exports[`Index page > renders correctly 1`] = `
           >
             <img
               alt="Microsoft"
-              class="max-h-full max-w-full object-contain brightness-0 invert"
+              class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
               height="48"
               src="/images/members/microsoft.svg"
               width="128"
@@ -1223,7 +1224,7 @@ exports[`Index page > renders correctly 1`] = `
           >
             <img
               alt="Alibaba Cloud"
-              class="max-h-full max-w-full object-contain brightness-0 invert"
+              class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
               height="48"
               src="/images/members/alibaba.png"
               width="128"
@@ -1239,7 +1240,7 @@ exports[`Index page > renders correctly 1`] = `
           >
             <img
               alt="Azul Systems"
-              class="max-h-full max-w-full object-contain brightness-0 invert"
+              class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
               height="48"
               src="/images/members/azul.svg"
               width="128"
@@ -1255,7 +1256,7 @@ exports[`Index page > renders correctly 1`] = `
           >
             <img
               alt="Red Hat"
-              class="max-h-full max-w-full object-contain brightness-0 invert"
+              class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
               height="48"
               src="/images/members/redhat.svg"
               width="128"

--- a/src/app/[locale]/business-benefits/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/business-benefits/__tests__/__snapshots__/page.test.tsx.snap
@@ -263,7 +263,7 @@ exports[`Business Benefits page > renders correctly 1`] = `
           >
             <img
               alt="Microsoft"
-              class="max-h-full max-w-full object-contain brightness-0 invert"
+              class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
               height="48"
               src="/images/members/microsoft.svg"
               width="128"
@@ -279,7 +279,7 @@ exports[`Business Benefits page > renders correctly 1`] = `
           >
             <img
               alt="Alibaba Cloud"
-              class="max-h-full max-w-full object-contain brightness-0 invert"
+              class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
               height="48"
               src="/images/members/alibaba.png"
               width="128"
@@ -295,7 +295,7 @@ exports[`Business Benefits page > renders correctly 1`] = `
           >
             <img
               alt="Azul Systems"
-              class="max-h-full max-w-full object-contain brightness-0 invert"
+              class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
               height="48"
               src="/images/members/azul.svg"
               width="128"
@@ -311,7 +311,7 @@ exports[`Business Benefits page > renders correctly 1`] = `
           >
             <img
               alt="Red Hat"
-              class="max-h-full max-w-full object-contain brightness-0 invert"
+              class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
               height="48"
               src="/images/members/redhat.svg"
               width="128"

--- a/src/app/[locale]/marketplace/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/marketplace/__tests__/__snapshots__/page.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`Marketplace page > renders correctly 1`] = `
       >
         <img
           alt="AQAvit Logo"
-          class="w-full"
+          class="w-full h-auto"
           height="110"
           src="/images/projects/aqavit-project.svg"
           width="110"

--- a/src/app/[locale]/news/author/[author]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/author/[author]/__tests__/__snapshots__/page.test.tsx.snap
@@ -112,13 +112,16 @@ exports[`AuthorNewsPage > renders header and news when posts exist 1`] = `
         <div
           class="flex flex-col w-full rounded-3xl newscard-2 bg-[#200D46]"
         >
-          <img
-            alt="blog banner image"
-            class="m-0.5 rounded-t-3xl h-[200px] object-cover w-full"
-            height="200"
-            src="/news/2025/06/author-news/opengraph-image"
-            width="385"
-          />
+          <div
+            class="relative h-[200px] m-0.5 rounded-t-3xl overflow-hidden"
+          >
+            <img
+              alt="blog banner image"
+              class="object-cover"
+              sizes="(max-width: 768px) 100vw, 385px"
+              src="/news/2025/06/author-news/opengraph-image"
+            />
+          </div>
           <div
             class="p-8 flex flex-col flex-1"
           >

--- a/src/app/[locale]/news/author/[author]/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/author/[author]/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
@@ -112,13 +112,16 @@ exports[`AuthorNewsPagePaginated > renders news and header for author and page w
         <div
           class="flex flex-col w-full rounded-3xl newscard-2 bg-[#200D46]"
         >
-          <img
-            alt="blog banner image"
-            class="m-0.5 rounded-t-3xl h-[200px] object-cover w-full"
-            height="200"
-            src="/news/2025/06/author-page-2-news/opengraph-image"
-            width="385"
-          />
+          <div
+            class="relative h-[200px] m-0.5 rounded-t-3xl overflow-hidden"
+          >
+            <img
+              alt="blog banner image"
+              class="object-cover"
+              sizes="(max-width: 768px) 100vw, 385px"
+              src="/news/2025/06/author-page-2-news/opengraph-image"
+            />
+          </div>
           <div
             class="p-8 flex flex-col flex-1"
           >

--- a/src/app/[locale]/news/tag/[tag]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/tag/[tag]/__tests__/__snapshots__/page.test.tsx.snap
@@ -91,13 +91,16 @@ exports[`TagsPage (tag root) > renders header and news when posts exist 1`] = `
         <div
           class="flex flex-col w-full rounded-3xl newscard-2 bg-[#200D46]"
         >
-          <img
-            alt="blog banner image"
-            class="m-0.5 rounded-t-3xl h-[200px] object-cover w-full"
-            height="200"
-            src="/news/2025/06/tagged-news/opengraph-image"
-            width="385"
-          />
+          <div
+            class="relative h-[200px] m-0.5 rounded-t-3xl overflow-hidden"
+          >
+            <img
+              alt="blog banner image"
+              class="object-cover"
+              sizes="(max-width: 768px) 100vw, 385px"
+              src="/news/2025/06/tagged-news/opengraph-image"
+            />
+          </div>
           <div
             class="p-8 flex flex-col flex-1"
           >
@@ -119,7 +122,7 @@ exports[`TagsPage (tag root) > renders header and news when posts exist 1`] = `
                 <span
                   class="text-sm text-pink-500"
                 >
-                  author
+                  Unknown Author
                 </span>
               </h3>
             </div>

--- a/src/app/[locale]/news/tag/[tag]/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/news/tag/[tag]/page/[page]/__tests__/__snapshots__/page.test.tsx.snap
@@ -91,13 +91,16 @@ exports[`TaggedNewsPage (paginated) > renders news and header for tag and page w
         <div
           class="flex flex-col w-full rounded-3xl newscard-2 bg-[#200D46]"
         >
-          <img
-            alt="blog banner image"
-            class="m-0.5 rounded-t-3xl h-[200px] object-cover w-full"
-            height="200"
-            src="/news/2025/06/tagged-page-2-news/opengraph-image"
-            width="385"
-          />
+          <div
+            class="relative h-[200px] m-0.5 rounded-t-3xl overflow-hidden"
+          >
+            <img
+              alt="blog banner image"
+              class="object-cover"
+              sizes="(max-width: 768px) 100vw, 385px"
+              src="/news/2025/06/tagged-page-2-news/opengraph-image"
+            />
+          </div>
           <div
             class="p-8 flex flex-col flex-1"
           >
@@ -119,7 +122,7 @@ exports[`TaggedNewsPage (paginated) > renders news and header for tag and page w
                 <span
                   class="text-sm text-pink-500"
                 >
-                  author
+                  Unknown Author
                 </span>
               </h3>
             </div>

--- a/src/app/[locale]/sustainers/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/sustainers/__tests__/__snapshots__/page.test.tsx.snap
@@ -1450,7 +1450,7 @@ exports[`Sustainers page > renders correctly 1`] = `
                 >
                   <img
                     alt="Kobalt"
-                    class="max-h-full max-w-full object-contain brightness-0 invert"
+                    class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
                     height="48"
                     src="/images/members/kobalt.png"
                     width="128"
@@ -1466,7 +1466,7 @@ exports[`Sustainers page > renders correctly 1`] = `
                 >
                   <img
                     alt="MacStadium"
-                    class="max-h-full max-w-full object-contain brightness-0 invert"
+                    class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
                     height="48"
                     src="/images/members/macstadium.svg"
                     width="128"
@@ -1482,7 +1482,7 @@ exports[`Sustainers page > renders correctly 1`] = `
                 >
                   <img
                     alt="Open-Elements"
-                    class="max-h-full max-w-full object-contain brightness-0 invert"
+                    class="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
                     height="48"
                     src="/images/members/openelements.svg"
                     width="128"

--- a/src/app/[locale]/temurin/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/[locale]/temurin/__tests__/__snapshots__/page.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`TemurinIndex page > renders correctly 1`] = `
         <img
           alt="Temurin Logo Background"
           class="object-contain"
+          sizes="1000px"
           src="/images/backgrounds/temurin-hero-img.png"
         />
       </div>
@@ -107,126 +108,126 @@ exports[`TemurinIndex page > renders correctly 1`] = `
             class="mt-6"
             data-testid="react-slick-mock"
           >
-            <span
-              class="px-4"
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Arm"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-arm-white.svg"
                 style="padding: 1em;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Atlassian"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-atlassian-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Dynatrace"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-dynatrace-white.png"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Mercedes-Benz Tech Innovation GmbH"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-mercedes-benz-white.png"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Michelin"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-michelin-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Microsoft"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-microsoft-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="MongoDB"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-mongodb-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Red Hat"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/Logo-RedHat-A-White-RGB.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="Societe Generale"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-societe-generale-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
-            <span
-              class="px-4"
+            </div>
+            <div
+              class="!flex items-center justify-center h-[100px] px-4"
             >
               <img
                 alt="T-Systems"
-                class="h-[100px] w-auto object-contain mx-auto"
+                class="w-auto h-auto object-contain mx-auto max-h-[100px]"
                 height="100"
                 src="/images/adopters/logo-t-systems-white.svg"
                 style="padding: 0px;"
                 width="200"
               />
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -244,126 +245,126 @@ exports[`TemurinIndex page > renders correctly 1`] = `
       class="mt-6"
       data-testid="react-slick-mock"
     >
-      <span
-        class="px-4"
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="Arm"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/logo-arm-white.svg"
           style="padding: 1em;"
           width="200"
         />
-      </span>
-      <span
-        class="px-4"
+      </div>
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="Atlassian"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/logo-atlassian-white.svg"
           style="padding: 0px;"
           width="200"
         />
-      </span>
-      <span
-        class="px-4"
+      </div>
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="Dynatrace"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/logo-dynatrace-white.png"
           style="padding: 0px;"
           width="200"
         />
-      </span>
-      <span
-        class="px-4"
+      </div>
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="Mercedes-Benz Tech Innovation GmbH"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/logo-mercedes-benz-white.png"
           style="padding: 0px;"
           width="200"
         />
-      </span>
-      <span
-        class="px-4"
+      </div>
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="Michelin"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/logo-michelin-white.svg"
           style="padding: 0px;"
           width="200"
         />
-      </span>
-      <span
-        class="px-4"
+      </div>
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="Microsoft"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/logo-microsoft-white.svg"
           style="padding: 0px;"
           width="200"
         />
-      </span>
-      <span
-        class="px-4"
+      </div>
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="MongoDB"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/logo-mongodb-white.svg"
           style="padding: 0px;"
           width="200"
         />
-      </span>
-      <span
-        class="px-4"
+      </div>
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="Red Hat"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/Logo-RedHat-A-White-RGB.svg"
           style="padding: 0px;"
           width="200"
         />
-      </span>
-      <span
-        class="px-4"
+      </div>
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="Societe Generale"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/logo-societe-generale-white.svg"
           style="padding: 0px;"
           width="200"
         />
-      </span>
-      <span
-        class="px-4"
+      </div>
+      <div
+        class="!flex items-center justify-center h-[100px] px-4"
       >
         <img
           alt="T-Systems"
-          class="h-[100px] w-auto object-contain mx-auto"
+          class="w-auto h-auto object-contain mx-auto max-h-[100px]"
           height="100"
           src="/images/adopters/logo-t-systems-white.svg"
           style="padding: 0px;"
           width="200"
         />
-      </span>
+      </div>
     </div>
   </div>
   <div

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -78,7 +78,7 @@ export default async function RootLayout({
   const locale = await getLocale();
 
   return (
-    <html lang={locale}>
+    <html lang={locale} data-scroll-behavior="smooth">
       <head>
         <link rel="sitemap" type="application/xml" href="/sitemap.xml"></link>
         <link

--- a/src/components/About/AQAvit/__tests__/__snapshots__/AQAvit.test.tsx.snap
+++ b/src/components/About/AQAvit/__tests__/__snapshots__/AQAvit.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`AQAvit component > should render correctly 1`] = `
       >
         <img
           alt="AQAvit Logo"
-          class="w-full"
+          class="w-full h-auto"
           height="110"
           src="/images/projects/aqavit-project.svg"
           width="110"

--- a/src/components/About/AQAvit/index.tsx
+++ b/src/components/About/AQAvit/index.tsx
@@ -12,7 +12,7 @@ const AQAvit = () => {
       <div className="aqavit-card gap-4 md:gap-10 flex flex-col md:flex-row justify-between md:items-center max-w-[1000px] mx-auto p-[32px] md:p-[64px]">
         <div className="max-w-[110px] ">
           <Image
-            className="w-full"
+            className="w-full h-auto"
             src="/images/projects/aqavit-project.svg"
             alt="AQAvit Logo"
             width={110}

--- a/src/components/EventCard/index.tsx
+++ b/src/components/EventCard/index.tsx
@@ -4,6 +4,7 @@ import { Link } from "@/i18n/navigation";
 import Image from "next/image";
 import { formatDate } from "@/utils/date";
 import { sanitizeString } from "@/utils/sanitize";
+import { getFormattedAuthorData } from "@/utils/authors";
 
 interface EventCardProps {
   post: {
@@ -20,9 +21,10 @@ interface EventCardProps {
     };
   };
   isEclipseNews?: boolean;
+  priority?: boolean;
 }
 
-const EventCard = ({ post, isEclipseNews }: EventCardProps) => {
+const EventCard = ({ post, isEclipseNews, priority }: EventCardProps) => {
   const locale = useLocale();
 
   const isExternalLink =
@@ -38,26 +40,33 @@ const EventCard = ({ post, isEclipseNews }: EventCardProps) => {
   const title = post.metadata.title || "Untitled";
   const description = post.metadata.description || "";
   const date = formatDate(post.metadata.date, locale) || "";
+  const authorName = post.metadata.author
+    ? getFormattedAuthorData(post.metadata.author).name
+    : undefined;
 
   return (
     <div className="flex flex-col w-full rounded-3xl newscard-2 bg-[#200D46]">
-      {post.metadata.featuredImage ? (
-        <Image
-          className="m-0.5 rounded-t-3xl h-[200px] object-cover w-full"
-          src={post.metadata.featuredImage}
-          width={385}
-          height={200}
-          alt="blog banner image"
-        />
-      ) : (
-        <Image
-          className="m-0.5 rounded-t-3xl h-[200px] object-cover w-full"
-          src={`/news/${post.year}/${post.month}/${post.slug}/opengraph-image`}
-          width={385}
-          height={200}
-          alt="blog banner image"
-        />
-      )}
+      <div className="relative h-[200px] m-0.5 rounded-t-3xl overflow-hidden">
+        {post.metadata.featuredImage ? (
+          <Image
+            className="object-cover"
+            src={post.metadata.featuredImage}
+            fill
+            sizes="(max-width: 768px) 100vw, 385px"
+            alt="blog banner image"
+            priority={priority}
+          />
+        ) : (
+          <Image
+            className="object-cover"
+            src={`/news/${post.year}/${post.month}/${post.slug}/opengraph-image`}
+            fill
+            sizes="(max-width: 768px) 100vw, 385px"
+            alt="blog banner image"
+            priority={priority}
+          />
+        )}
+      </div>
 
       <div className="p-8 flex flex-col flex-1">
         <h3
@@ -70,9 +79,9 @@ const EventCard = ({ post, isEclipseNews }: EventCardProps) => {
         <div className="flex justify-between py-2">
           <h3 className="flex flex-col gap-1 tab-button-text text-white">
             <span>{date}</span>
-            {post.metadata.author && (
+            {authorName && (
               <span className="text-sm text-pink-500">
-                {post.metadata.author}
+                {authorName}
               </span>
             )}
           </h3>

--- a/src/components/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -666,6 +666,7 @@ exports[`Footer component > renders correctly 1`] = `
             >
               <img
                 alt="Deploys by Netlify"
+                class="w-auto h-auto"
                 height="25"
                 src="/images/netlify-light.svg"
                 width="80"
@@ -1381,6 +1382,7 @@ exports[`Footer component > renders correctly 1`] = `
             >
               <img
                 alt="Deploys by Netlify"
+                class="w-auto h-auto"
                 height="25"
                 src="/images/netlify-light.svg"
                 width="80"

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -312,7 +312,7 @@ const Footer: React.FC = () => {
                               if (
                                 link.disclaimerMessage &&
                                 window.confirm(
-                                  link.disclaimerMessage.defaultText
+                                  link.disclaimerMessage.defaultText,
                                 )
                               ) {
                                 window.open(link.url, "_blank");
@@ -372,6 +372,7 @@ const Footer: React.FC = () => {
                   alt="Deploys by Netlify"
                   width={80}
                   height={25}
+                  className="w-auto h-auto"
                 />
               </a>
             </div>
@@ -416,6 +417,7 @@ const Footer: React.FC = () => {
                   alt="Deploys by Netlify"
                   width={80}
                   height={25}
+                  className="w-auto h-auto"
                 />
               </a>
             </div>

--- a/src/components/HeroSection/index.tsx
+++ b/src/components/HeroSection/index.tsx
@@ -44,6 +44,7 @@ const HeroSection = ({ latestLTS }: HeroSectionProps) => {
             src="/images/backgrounds/temurin-hero-img.png"
             alt="Temurin Logo Background"
             fill
+            sizes="1000px"
             className="object-contain"
             priority
           />

--- a/src/components/LogoCarousel/index.tsx
+++ b/src/components/LogoCarousel/index.tsx
@@ -68,16 +68,16 @@ const LogoCarousel = () => {
       </h2>
       <Slider {...settings} className="mt-6">
         {featuredAdopters.map((adopter, index) => (
-            <span key={index} className="px-4">
+            <div key={index} className="!flex items-center justify-center h-[100px] px-4">
             <Image
               width={200}
               height={100}
               src={`/images/${adopter.logo_white}`}
               alt={adopter.name}
-              className="h-[100px] w-auto object-contain mx-auto"
+              className="w-auto h-auto object-contain mx-auto max-h-[100px]"
               style={{ padding: adopter.logoPadding || 0 }}
             />
-            </span>
+            </div>
         ))}
       </Slider>
     </div>

--- a/src/components/LogosGrid/index.tsx
+++ b/src/components/LogosGrid/index.tsx
@@ -52,7 +52,7 @@ const LogosGrid = ({ logos, type }: LogosGridProps) => {
                       height={100}
                       src={`/images/${data.logo}`}
                       alt={data.name}
-                      className="max-h-16 md:max-h-20 m-0 relative z-10 transform group-hover:scale-110 transition-transform duration-300"
+                      className="max-h-16 md:max-h-20 w-auto m-0 relative z-10 transform group-hover:scale-110 transition-transform duration-300"
                     />
                   </div>
                 </motion.a>

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -216,6 +216,7 @@ const NavBar = ({ locale }: { locale: string }) => {
               width={0}
               height={0}
               className="h-10 w-auto"
+              priority
             />
           </Link>
           <div className="flex items-center gap-4">
@@ -346,6 +347,7 @@ const NavBar = ({ locale }: { locale: string }) => {
                 alt="Adoptium Logo"
                 width={0}
                 height={0}
+                priority
               />
             </Link>
             <button

--- a/src/components/News/NewsCardList/index.tsx
+++ b/src/components/News/NewsCardList/index.tsx
@@ -61,6 +61,7 @@ const NewsCardList: React.FC<NewsCardListProps> = ({
               key={`post-${rowIndex}-${index}`}
               post={post}
               isEclipseNews={post.metadata.tags?.includes("eclipse-news")}
+              priority={rowIndex === 0}
             />
           ))}
         </div>

--- a/src/components/News/RelatedArticles/index.tsx
+++ b/src/components/News/RelatedArticles/index.tsx
@@ -3,50 +3,57 @@ import EventCard from "@/components/EventCard";
 import { getBlogPosts } from "@/utils/markdown";
 
 interface RelatedArticlesProps {
-    currentSlug: string;
-    tags?: string[];
-    maxArticles?: number;
+  currentSlug: string;
+  tags?: string[];
+  maxArticles?: number;
 }
 
-const RelatedArticles: React.FC<RelatedArticlesProps> = ({ currentSlug, tags = [], maxArticles = 3 }) => {
-    // Get all posts except the current one
-    const posts = getBlogPosts().filter((post) => post.slug !== currentSlug);
+const RelatedArticles: React.FC<RelatedArticlesProps> = ({
+  currentSlug,
+  tags = [],
+  maxArticles = 3,
+}) => {
+  // Get all posts except the current one
+  const posts = getBlogPosts().filter((post) => post.slug !== currentSlug);
 
-    // If tags are provided, filter by shared tags, otherwise just pick latest
-    let related = posts;
-    if (tags.length > 0) {
-        related = posts.filter((post) =>
-            post.metadata.tags?.some((tag) => tags.includes(tag))
-        );
-    }
-
-    // Sort by date (newest first)
-    related = related.sort((a, b) => {
-        const dateA = new Date(a.metadata.date).getTime();
-        const dateB = new Date(b.metadata.date).getTime();
-        return dateB - dateA;
-    });
-
-    // Limit to maxArticles
-    related = related.slice(0, maxArticles);
-
-    if (related.length === 0) return null;
-
-    return (
-        <div className="mt-16 w-full max-w-[1264px] px-0 sm:px-6 mx-auto py-8 md:py-16">
-            <div className="w-full max-w-[670px] mx-auto flex flex-col items-center justify-center px-4 sm:px-0">
-                <h2 className="text-5xl leading-[116%] text-white text-center font-semibold">Related Articles</h2>
-                <p className="text-lg leading-7 text-grey-300 text-center mt-4">
-                    Explore more articles that might interest you based on your reading history.
-                </p>
-            </div>
-            <div className="flex justify-center flex-wrap items-center gap-5 pt-8 px-2 sm:px-0">
-                {related.map((post) => (
-                    <EventCard key={post.slug} post={post} />
-                ))}
-            </div>
-        </div>
+  // If tags are provided, filter by shared tags, otherwise just pick latest
+  let related = posts;
+  if (tags.length > 0) {
+    related = posts.filter((post) =>
+      post.metadata.tags?.some((tag) => tags.includes(tag)),
     );
+  }
+
+  // Sort by date (newest first)
+  related = related.sort((a, b) => {
+    const dateA = new Date(a.metadata.date).getTime();
+    const dateB = new Date(b.metadata.date).getTime();
+    return dateB - dateA;
+  });
+
+  // Limit to maxArticles
+  related = related.slice(0, maxArticles);
+
+  if (related.length === 0) return null;
+
+  return (
+    <div className="mt-16 w-full max-w-[1264px] px-0 sm:px-6 mx-auto py-8 md:py-16">
+      <div className="w-full max-w-[670px] mx-auto flex flex-col items-center justify-center px-4 sm:px-0">
+        <h2 className="text-5xl leading-[116%] text-white text-center font-semibold">
+          Related Articles
+        </h2>
+        <p className="text-lg leading-7 text-grey-300 text-center mt-4">
+          Explore more articles that might interest you based on your reading
+          history.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 justify-items-center pt-8 px-2 sm:px-0">
+        {related.map((post) => (
+          <EventCard key={post.slug} post={post} />
+        ))}
+      </div>
+    </div>
+  );
 };
 
 export default RelatedArticles;

--- a/src/components/Testimonials/index.tsx
+++ b/src/components/Testimonials/index.tsx
@@ -194,7 +194,7 @@ const Testimonials: React.FC<TestimonialsProps> = ({ type }) => {
                   <Image
                     src={testimonial.companyLogo}
                     alt={testimonial.companyName}
-                    className="max-h-full max-w-full object-contain brightness-0 invert"
+                    className="max-h-full max-w-full w-auto h-auto object-contain brightness-0 invert"
                     width={128}
                     height={48}
                   />

--- a/src/components/WGProjects/index.tsx
+++ b/src/components/WGProjects/index.tsx
@@ -78,7 +78,7 @@ const WGProjects = () => {
                 <Image
                   src={`/images/projects/${project.imagePath}`}
                   alt={`${project.title} logo`}
-                  className="w-[140px]"
+                  className="w-[140px] h-auto"
                   width={140}
                   height={70}
                 />


### PR DESCRIPTION
# Description of change

- Add w-auto/h-auto to Image components where CSS overrides width or height to maintain aspect ratio (LogosGrid, Testimonials, WGProjects, AQAvit, Footer, LogoCarousel)
- Add priority prop to NavBar logo and first-row EventCard images to fix LCP warnings for above-the-fold images
- Add sizes prop to HeroSection background image with fill
- Add data-scroll-behavior="smooth" to <html> element in layout
- Use grid layout for RelatedArticles to display cards side by side
- Resolve author ID to display name in EventCard via getFormattedAuthorData
- Update affected snapshots

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
