### PR TITLE
Redesign release notes page

### DIFF
--- a/src/components/Content/ReleaseNotes/__tests__/__snapshots__/ReleaseNotesRender.test.tsx.snap
+++ b/src/components/Content/ReleaseNotes/__tests__/__snapshots__/ReleaseNotesRender.test.tsx.snap
@@ -3,38 +3,38 @@
 exports[`ReleaseNotesRender component > should render correctly - no release notes 1`] = `
 <div>
   <div
-    class="release-notes-container mx-auto w-full max-w-[1400px] px-4 lg:px-8 py-6 items-center text-center justify-center"
+    class="release-notes-container mx-auto w-full max-w-5xl px-6 lg:px-0 pb-20 pt-2"
   >
     <div
-      class="self-stretch text-center text-lightgrey text-[20px] font-normal leading-[140%] mx-auto max-w-[860px] px-2 w-full mb-4"
+      class="text-center mb-10"
     >
       <h2
-        class="text-4xl font-bold text-pink mb-2 tracking-tight drop-shadow-sm"
+        class="text-[42px] font-semibold tracking-tight text-white mb-1"
       >
         release_name_mock
       </h2>
     </div>
     <div
-      class="pt-3 w-full flex justify-center h-full"
+      class="w-full"
     >
       <div
-        class="w-full flex-grow"
+        class="w-full"
       >
         <div
-          class="bg-gradient-to-br from-[#200E46]/90 to-[#2B1A4F]/90 rounded-3xl border border-white/20 shadow-lg p-8 text-center"
+          class="rounded-2xl bg-white/[0.04] backdrop-blur-xl border border-white/[0.08] p-12 text-center"
         >
           <h2
-            class="text-3xl font-bold text-pink tracking-tight drop-shadow-sm mb-4"
+            class="text-2xl font-semibold text-white tracking-tight mb-3"
           >
             Text
           </h2>
           <span
-            class="text-white/80 text-lg"
+            class="text-white/50 text-base"
           >
             Text
              
             <code
-              class="bg-[#14003c] px-2 py-1 rounded text-pink"
+              class="bg-white/[0.06] px-2 py-1 rounded-md text-pink text-sm font-mono"
             >
               ?version=x.x.x
             </code>
@@ -49,44 +49,59 @@ exports[`ReleaseNotesRender component > should render correctly - no release not
 exports[`ReleaseNotesRender component > should render correctly - version not defined 1`] = `
 <div>
   <div
-    class="release-notes-container mx-auto w-full max-w-[1400px] px-4 lg:px-8 py-6 items-center text-center justify-center"
+    class="release-notes-container mx-auto w-full max-w-5xl px-6 lg:px-0 pb-20 pt-2"
   >
     <div
-      class="self-stretch text-center text-lightgrey text-[20px] font-normal leading-[140%] mx-auto max-w-[860px] px-2 w-full mb-4"
+      class="text-center mb-10"
     >
       <h2
-        class="text-4xl font-bold text-pink mb-2 tracking-tight drop-shadow-sm"
+        class="text-[42px] font-semibold tracking-tight text-white mb-1"
       >
         release_name_mock
       </h2>
     </div>
     <div
-      class="pt-3 w-full flex justify-center h-full"
+      class="w-full"
     >
       <div
-        class="w-full flex-grow"
+        class="w-full"
       >
-        <p
-          class="release-notes-description"
-        >
-          Text
-        </p>
-        <p
-          class="release-notes-description"
-        >
-          <strong>
-            The total number of fixes marked as P1 is: 2
-          </strong>
-        </p>
         <div
-          class="flex items-center justify-between gap-4 mb-0 bg-[#2B1A4F]/90 rounded-t-2xl border border-white/10 px-4 py-3"
+          class="text-center mb-10 max-w-2xl mx-auto"
+        >
+          <p
+            class="text-base text-white/50 leading-relaxed mb-4"
+          >
+            Text
+          </p>
+          <div
+            class="inline-flex items-center gap-2 rounded-full bg-white/[0.04] border border-white/[0.08] px-4 py-1.5"
+          >
+            <span
+              class="w-2 h-2 rounded-full bg-pink/80"
+            />
+            <span
+              class="text-sm text-white/60"
+            >
+              <span
+                class="font-medium text-white/80"
+              >
+                2
+              </span>
+               
+              P1 fixes
+            </span>
+          </div>
+        </div>
+        <div
+          class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6"
         >
           <div
-            class="flex items-center gap-3 flex-wrap"
+            class="flex items-center gap-2 flex-wrap"
           >
             <select
               aria-label="Filter by priority"
-              class="bg-[#231146]/60 text-white/90 text-sm border border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-pink"
+              class="appearance-none bg-white/[0.04] text-white/70 text-sm border border-white/[0.08] rounded-lg px-3 py-2 focus:outline-none focus:border-white/20 focus:bg-white/[0.06] transition-all duration-200 cursor-pointer"
             >
               <option
                 value=""
@@ -102,7 +117,7 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
             </select>
             <select
               aria-label="Filter by type"
-              class="bg-[#231146]/60 text-white/90 text-sm border border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-pink"
+              class="appearance-none bg-white/[0.04] text-white/70 text-sm border border-white/[0.08] rounded-lg px-3 py-2 focus:outline-none focus:border-white/20 focus:bg-white/[0.06] transition-all duration-200 cursor-pointer"
             >
               <option
                 value=""
@@ -117,7 +132,7 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
             </select>
             <select
               aria-label="Filter by component"
-              class="bg-[#231146]/60 text-white/90 text-sm border border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-pink"
+              class="appearance-none bg-white/[0.04] text-white/70 text-sm border border-white/[0.08] rounded-lg px-3 py-2 focus:outline-none focus:border-white/20 focus:bg-white/[0.06] transition-all duration-200 cursor-pointer"
             >
               <option
                 value=""
@@ -132,13 +147,13 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
             </select>
           </div>
           <button
-            class="text-sm font-medium text-white/80 hover:text-white bg-[#231146]/60 border border-white/10 rounded-md px-4 py-1.5 hover:bg-[#231146] transition-colors"
+            class="text-sm font-medium text-white/50 hover:text-white bg-white/[0.04] border border-white/[0.08] rounded-lg px-4 py-2 hover:bg-white/[0.08] hover:border-white/[0.14] transition-all duration-200"
           >
             Export CSV
           </button>
         </div>
         <div
-          class="overflow-x-auto rounded-b-2xl border border-t-0 border-white/10 bg-[#231146]/50 backdrop-blur-sm shadow-lg"
+          class="overflow-x-auto rounded-2xl border border-white/[0.08] bg-white/[0.02] backdrop-blur-xl"
         >
           <table
             aria-label="Release Notes"
@@ -146,32 +161,36 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
           >
             <thead>
               <tr
-                class="bg-[#2B1A4F]/98 border-b-2 border-pink/40"
+                class="border-b border-white/[0.08]"
               >
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider cursor-pointer select-none hover:text-pink transition-colors w-[120px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase cursor-pointer select-none hover:text-white/70 transition-colors duration-200 w-[100px]"
                 >
                   Priority
                    
-                  ▲
+                  <span
+                    class="text-white/20"
+                  >
+                    ▲
+                  </span>
                 </th>
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider w-[130px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase w-[120px]"
                 >
                   Type
                 </th>
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider w-[170px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase w-[160px]"
                 >
                   Component
                 </th>
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider w-[150px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase w-[130px]"
                 >
                   Issue
                 </th>
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider min-w-[300px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase min-w-[300px]"
                 >
                   Title
                 </th>
@@ -179,34 +198,34 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
             </thead>
             <tbody>
               <tr
-                class="border-b border-white/5 transition-all duration-200 hover:bg-white/[0.08] hover:-translate-y-px hover:shadow-md bg-white/[0.02]"
+                class="border-b border-white/[0.04] transition-colors duration-150 hover:bg-white/[0.04] "
                 data-row="true"
               >
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5"
                   data-field="priority"
                 >
                   <span
-                    class="badge bg-secondary priority-1"
+                    class="badge priority-1"
                     title="P1 - Blocks development and/or testing work, production could not run."
                   >
                     P1
                   </span>
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5 text-white/60 text-sm"
                   data-field="type"
                 >
                   Bug
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5 text-white/60 text-sm"
                   data-field="component"
                 >
                   component_mock
                 </td>
                 <td
-                  class="px-4 py-3"
+                  class="px-5 py-3.5"
                   data-field="id"
                 >
                   <a
@@ -219,41 +238,41 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
                   </a>
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90 break-words"
+                  class="px-5 py-3.5 text-white/70 text-sm leading-relaxed break-words"
                   data-field="title"
                 >
                   title_mock
                 </td>
               </tr>
               <tr
-                class="border-b border-white/5 transition-all duration-200 hover:bg-white/[0.08] hover:-translate-y-px hover:shadow-md "
+                class="border-b border-white/[0.04] transition-colors duration-150 hover:bg-white/[0.04] bg-white/[0.01]"
                 data-row="true"
               >
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5"
                   data-field="priority"
                 >
                   <span
-                    class="badge bg-secondary priority-1"
+                    class="badge priority-1"
                     title="P1 - Blocks development and/or testing work, production could not run."
                   >
                     P1
                   </span>
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5 text-white/60 text-sm"
                   data-field="type"
                 >
                   Bug
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5 text-white/60 text-sm"
                   data-field="component"
                 >
                   component_mock
                 </td>
                 <td
-                  class="px-4 py-3"
+                  class="px-5 py-3.5"
                   data-field="id"
                 >
                   <a
@@ -266,7 +285,7 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
                   </a>
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90 break-words"
+                  class="px-5 py-3.5 text-white/70 text-sm leading-relaxed break-words"
                   data-field="title"
                 >
                   title_mock
@@ -276,16 +295,16 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
           </table>
         </div>
         <div
-          class="flex items-center justify-between gap-4 mt-4 bg-[#231146]/30 rounded-lg border border-white/[0.08] p-3 shadow-md text-white/85"
+          class="flex items-center justify-between gap-4 mt-4 px-1"
         >
           <div
-            class="flex items-center gap-2 text-sm"
+            class="flex items-center gap-2 text-sm text-white/40"
           >
             <span>
-              Rows per page:
+              Rows
             </span>
             <select
-              class="bg-[#231146]/60 text-white/85 border border-white/10 rounded-md px-2 py-1 text-sm focus:outline-none focus:border-pink"
+              class="appearance-none bg-white/[0.04] text-white/60 border border-white/[0.08] rounded-lg px-2 py-1 text-sm focus:outline-none focus:border-white/20 transition-all duration-200 cursor-pointer"
             >
               <option
                 value="20"
@@ -305,23 +324,27 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
             </select>
           </div>
           <div
-            class="flex items-center gap-3 text-sm"
+            class="flex items-center gap-4 text-sm text-white/40"
           >
             <span>
               1–2 of 2
             </span>
-            <button
-              class="px-2 py-1 rounded bg-[#231146]/40 border border-white/5 hover:bg-pink/15 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
-              disabled=""
+            <div
+              class="flex items-center gap-1"
             >
-              ‹
-            </button>
-            <button
-              class="px-2 py-1 rounded bg-[#231146]/40 border border-white/5 hover:bg-pink/15 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
-              disabled=""
-            >
-              ›
-            </button>
+              <button
+                class="w-8 h-8 flex items-center justify-center rounded-lg bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.08] disabled:opacity-25 disabled:cursor-not-allowed transition-all duration-200 text-white/60"
+                disabled=""
+              >
+                ‹
+              </button>
+              <button
+                class="w-8 h-8 flex items-center justify-center rounded-lg bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.08] disabled:opacity-25 disabled:cursor-not-allowed transition-all duration-200 text-white/60"
+                disabled=""
+              >
+                ›
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -333,44 +356,59 @@ exports[`ReleaseNotesRender component > should render correctly - version not de
 exports[`ReleaseNotesRender component > should render correctly 1`] = `
 <div>
   <div
-    class="release-notes-container mx-auto w-full max-w-[1400px] px-4 lg:px-8 py-6 items-center text-center justify-center"
+    class="release-notes-container mx-auto w-full max-w-5xl px-6 lg:px-0 pb-20 pt-2"
   >
     <div
-      class="self-stretch text-center text-lightgrey text-[20px] font-normal leading-[140%] mx-auto max-w-[860px] px-2 w-full mb-4"
+      class="text-center mb-10"
     >
       <h2
-        class="text-4xl font-bold text-pink mb-2 tracking-tight drop-shadow-sm"
+        class="text-[42px] font-semibold tracking-tight text-white mb-1"
       >
         release_name_mock
       </h2>
     </div>
     <div
-      class="pt-3 w-full flex justify-center h-full"
+      class="w-full"
     >
       <div
-        class="w-full flex-grow"
+        class="w-full"
       >
-        <p
-          class="release-notes-description"
-        >
-          Text
-        </p>
-        <p
-          class="release-notes-description"
-        >
-          <strong>
-            The total number of fixes marked as P1 is: 2
-          </strong>
-        </p>
         <div
-          class="flex items-center justify-between gap-4 mb-0 bg-[#2B1A4F]/90 rounded-t-2xl border border-white/10 px-4 py-3"
+          class="text-center mb-10 max-w-2xl mx-auto"
+        >
+          <p
+            class="text-base text-white/50 leading-relaxed mb-4"
+          >
+            Text
+          </p>
+          <div
+            class="inline-flex items-center gap-2 rounded-full bg-white/[0.04] border border-white/[0.08] px-4 py-1.5"
+          >
+            <span
+              class="w-2 h-2 rounded-full bg-pink/80"
+            />
+            <span
+              class="text-sm text-white/60"
+            >
+              <span
+                class="font-medium text-white/80"
+              >
+                2
+              </span>
+               
+              P1 fixes
+            </span>
+          </div>
+        </div>
+        <div
+          class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6"
         >
           <div
-            class="flex items-center gap-3 flex-wrap"
+            class="flex items-center gap-2 flex-wrap"
           >
             <select
               aria-label="Filter by priority"
-              class="bg-[#231146]/60 text-white/90 text-sm border border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-pink"
+              class="appearance-none bg-white/[0.04] text-white/70 text-sm border border-white/[0.08] rounded-lg px-3 py-2 focus:outline-none focus:border-white/20 focus:bg-white/[0.06] transition-all duration-200 cursor-pointer"
             >
               <option
                 value=""
@@ -386,7 +424,7 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
             </select>
             <select
               aria-label="Filter by type"
-              class="bg-[#231146]/60 text-white/90 text-sm border border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-pink"
+              class="appearance-none bg-white/[0.04] text-white/70 text-sm border border-white/[0.08] rounded-lg px-3 py-2 focus:outline-none focus:border-white/20 focus:bg-white/[0.06] transition-all duration-200 cursor-pointer"
             >
               <option
                 value=""
@@ -401,7 +439,7 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
             </select>
             <select
               aria-label="Filter by component"
-              class="bg-[#231146]/60 text-white/90 text-sm border border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-pink"
+              class="appearance-none bg-white/[0.04] text-white/70 text-sm border border-white/[0.08] rounded-lg px-3 py-2 focus:outline-none focus:border-white/20 focus:bg-white/[0.06] transition-all duration-200 cursor-pointer"
             >
               <option
                 value=""
@@ -416,13 +454,13 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
             </select>
           </div>
           <button
-            class="text-sm font-medium text-white/80 hover:text-white bg-[#231146]/60 border border-white/10 rounded-md px-4 py-1.5 hover:bg-[#231146] transition-colors"
+            class="text-sm font-medium text-white/50 hover:text-white bg-white/[0.04] border border-white/[0.08] rounded-lg px-4 py-2 hover:bg-white/[0.08] hover:border-white/[0.14] transition-all duration-200"
           >
             Export CSV
           </button>
         </div>
         <div
-          class="overflow-x-auto rounded-b-2xl border border-t-0 border-white/10 bg-[#231146]/50 backdrop-blur-sm shadow-lg"
+          class="overflow-x-auto rounded-2xl border border-white/[0.08] bg-white/[0.02] backdrop-blur-xl"
         >
           <table
             aria-label="Release Notes"
@@ -430,32 +468,36 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
           >
             <thead>
               <tr
-                class="bg-[#2B1A4F]/98 border-b-2 border-pink/40"
+                class="border-b border-white/[0.08]"
               >
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider cursor-pointer select-none hover:text-pink transition-colors w-[120px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase cursor-pointer select-none hover:text-white/70 transition-colors duration-200 w-[100px]"
                 >
                   Priority
                    
-                  ▲
+                  <span
+                    class="text-white/20"
+                  >
+                    ▲
+                  </span>
                 </th>
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider w-[130px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase w-[120px]"
                 >
                   Type
                 </th>
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider w-[170px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase w-[160px]"
                 >
                   Component
                 </th>
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider w-[150px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase w-[130px]"
                 >
                   Issue
                 </th>
                 <th
-                  class="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider min-w-[300px]"
+                  class="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase min-w-[300px]"
                 >
                   Title
                 </th>
@@ -463,34 +505,34 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
             </thead>
             <tbody>
               <tr
-                class="border-b border-white/5 transition-all duration-200 hover:bg-white/[0.08] hover:-translate-y-px hover:shadow-md bg-white/[0.02]"
+                class="border-b border-white/[0.04] transition-colors duration-150 hover:bg-white/[0.04] "
                 data-row="true"
               >
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5"
                   data-field="priority"
                 >
                   <span
-                    class="badge bg-secondary priority-1"
+                    class="badge priority-1"
                     title="P1 - Blocks development and/or testing work, production could not run."
                   >
                     P1
                   </span>
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5 text-white/60 text-sm"
                   data-field="type"
                 >
                   Bug
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5 text-white/60 text-sm"
                   data-field="component"
                 >
                   component_mock
                 </td>
                 <td
-                  class="px-4 py-3"
+                  class="px-5 py-3.5"
                   data-field="id"
                 >
                   <a
@@ -503,41 +545,41 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
                   </a>
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90 break-words"
+                  class="px-5 py-3.5 text-white/70 text-sm leading-relaxed break-words"
                   data-field="title"
                 >
                   title_mock
                 </td>
               </tr>
               <tr
-                class="border-b border-white/5 transition-all duration-200 hover:bg-white/[0.08] hover:-translate-y-px hover:shadow-md "
+                class="border-b border-white/[0.04] transition-colors duration-150 hover:bg-white/[0.04] bg-white/[0.01]"
                 data-row="true"
               >
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5"
                   data-field="priority"
                 >
                   <span
-                    class="badge bg-secondary priority-1"
+                    class="badge priority-1"
                     title="P1 - Blocks development and/or testing work, production could not run."
                   >
                     P1
                   </span>
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5 text-white/60 text-sm"
                   data-field="type"
                 >
                   Bug
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90"
+                  class="px-5 py-3.5 text-white/60 text-sm"
                   data-field="component"
                 >
                   component_mock
                 </td>
                 <td
-                  class="px-4 py-3"
+                  class="px-5 py-3.5"
                   data-field="id"
                 >
                   <a
@@ -550,7 +592,7 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
                   </a>
                 </td>
                 <td
-                  class="px-4 py-3 text-white/90 break-words"
+                  class="px-5 py-3.5 text-white/70 text-sm leading-relaxed break-words"
                   data-field="title"
                 >
                   title_mock
@@ -560,16 +602,16 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
           </table>
         </div>
         <div
-          class="flex items-center justify-between gap-4 mt-4 bg-[#231146]/30 rounded-lg border border-white/[0.08] p-3 shadow-md text-white/85"
+          class="flex items-center justify-between gap-4 mt-4 px-1"
         >
           <div
-            class="flex items-center gap-2 text-sm"
+            class="flex items-center gap-2 text-sm text-white/40"
           >
             <span>
-              Rows per page:
+              Rows
             </span>
             <select
-              class="bg-[#231146]/60 text-white/85 border border-white/10 rounded-md px-2 py-1 text-sm focus:outline-none focus:border-pink"
+              class="appearance-none bg-white/[0.04] text-white/60 border border-white/[0.08] rounded-lg px-2 py-1 text-sm focus:outline-none focus:border-white/20 transition-all duration-200 cursor-pointer"
             >
               <option
                 value="20"
@@ -589,23 +631,27 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
             </select>
           </div>
           <div
-            class="flex items-center gap-3 text-sm"
+            class="flex items-center gap-4 text-sm text-white/40"
           >
             <span>
               1–2 of 2
             </span>
-            <button
-              class="px-2 py-1 rounded bg-[#231146]/40 border border-white/5 hover:bg-pink/15 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
-              disabled=""
+            <div
+              class="flex items-center gap-1"
             >
-              ‹
-            </button>
-            <button
-              class="px-2 py-1 rounded bg-[#231146]/40 border border-white/5 hover:bg-pink/15 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
-              disabled=""
-            >
-              ›
-            </button>
+              <button
+                class="w-8 h-8 flex items-center justify-center rounded-lg bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.08] disabled:opacity-25 disabled:cursor-not-allowed transition-all duration-200 text-white/60"
+                disabled=""
+              >
+                ‹
+              </button>
+              <button
+                class="w-8 h-8 flex items-center justify-center rounded-lg bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.08] disabled:opacity-25 disabled:cursor-not-allowed transition-all duration-200 text-white/60"
+                disabled=""
+              >
+                ›
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Content/ReleaseNotes/index.tsx
+++ b/src/components/Content/ReleaseNotes/index.tsx
@@ -197,50 +197,68 @@ const ReleaseNotesRender = () => {
   return (
     <div
       ref={ref}
-      className="release-notes-container mx-auto w-full max-w-[1400px] px-4 lg:px-8 py-6 items-center text-center justify-center"
+      className="release-notes-container mx-auto w-full max-w-5xl px-6 lg:px-0 pb-20 pt-2"
     >
-      <div className="self-stretch text-center text-lightgrey text-[20px] font-normal leading-[140%] mx-auto max-w-[860px] px-2 w-full mb-4">
-        <h2 className="text-4xl font-bold text-pink mb-2 tracking-tight drop-shadow-sm">
+      {/* Version title */}
+      <div className="text-center mb-10">
+        <h2 className="text-[42px] font-semibold tracking-tight text-white mb-1">
           {releaseNotesVersion}
         </h2>
       </div>
-      <div className="pt-3 w-full flex justify-center h-full">
+
+      <div className="w-full">
         {!releaseNoteDataBag ? (
-          <div className="flex-grow flex items-center justify-center">
-            <div
-              className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-pink"
-              aria-label="loading spinner"
-            />
+          <div className="flex items-center justify-center py-32">
+            <div className="flex flex-col items-center gap-4">
+              <div
+                className="h-8 w-8 rounded-full border-2 border-white/10 border-t-pink animate-spin"
+                aria-label="loading spinner"
+              />
+              <span className="text-sm text-white/30 tracking-wide">
+                Loading release notes…
+              </span>
+            </div>
           </div>
         ) : (
-          <div className="w-full flex-grow">
+          <div className="w-full">
             {!releaseNotesVersion || releaseNoteDataBag?.isValid === false ? (
-              <div className="bg-gradient-to-br from-[#200E46]/90 to-[#2B1A4F]/90 rounded-3xl border border-white/20 shadow-lg p-8 text-center">
-                <h2 className="text-3xl font-bold text-pink tracking-tight drop-shadow-sm mb-4">
+              <div className="rounded-2xl bg-white/[0.04] backdrop-blur-xl border border-white/[0.08] p-12 text-center">
+                <h2 className="text-2xl font-semibold text-white tracking-tight mb-3">
                   {t("couldnt-find-release-notes")}
                 </h2>
-                <span className="text-white/80 text-lg">
+                <span className="text-white/50 text-base">
                   {t("not-found-helper")}{" "}
-                  <code className="bg-[#14003c] px-2 py-1 rounded text-pink">
+                  <code className="bg-white/[0.06] px-2 py-1 rounded-md text-pink text-sm font-mono">
                     ?version=x.x.x
                   </code>
                 </span>
               </div>
             ) : (
               <>
-                <p className="release-notes-description">{t("description")}</p>
-                <p className="release-notes-description">
-                  <strong>{`The total number of fixes marked as P1 is: ${totalP1}`}</strong>
-                </p>
+                {/* Description + stats */}
+                <div className="text-center mb-10 max-w-2xl mx-auto">
+                  <p className="text-base text-white/50 leading-relaxed mb-4">
+                    {t("description")}
+                  </p>
+                  <div className="inline-flex items-center gap-2 rounded-full bg-white/[0.04] border border-white/[0.08] px-4 py-1.5">
+                    <span className="w-2 h-2 rounded-full bg-pink/80" />
+                    <span className="text-sm text-white/60">
+                      <span className="font-medium text-white/80">
+                        {totalP1}
+                      </span>{" "}
+                      P1 fixes
+                    </span>
+                  </div>
+                </div>
 
                 {/* Toolbar */}
-                <div className="flex items-center justify-between gap-4 mb-0 bg-[#2B1A4F]/90 rounded-t-2xl border border-white/10 px-4 py-3">
-                  <div className="flex items-center gap-3 flex-wrap">
+                <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <select
                       aria-label="Filter by priority"
                       value={filters.priority}
                       onChange={(e) => updateFilter("priority", e.target.value)}
-                      className="bg-[#231146]/60 text-white/90 text-sm border border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-pink"
+                      className="appearance-none bg-white/[0.04] text-white/70 text-sm border border-white/[0.08] rounded-lg px-3 py-2 focus:outline-none focus:border-white/20 focus:bg-white/[0.06] transition-all duration-200 cursor-pointer"
                     >
                       <option value="">All Priorities</option>
                       {priorities.map((p) => (
@@ -256,7 +274,7 @@ const ReleaseNotesRender = () => {
                         (isEnhancementDefault ? "Enhancement" : "")
                       }
                       onChange={(e) => updateFilter("type", e.target.value)}
-                      className="bg-[#231146]/60 text-white/90 text-sm border border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-pink"
+                      className="appearance-none bg-white/[0.04] text-white/70 text-sm border border-white/[0.08] rounded-lg px-3 py-2 focus:outline-none focus:border-white/20 focus:bg-white/[0.06] transition-all duration-200 cursor-pointer"
                     >
                       <option value="">All Types</option>
                       {types.map((ty) => (
@@ -271,7 +289,7 @@ const ReleaseNotesRender = () => {
                       onChange={(e) =>
                         updateFilter("component", e.target.value)
                       }
-                      className="bg-[#231146]/60 text-white/90 text-sm border border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-pink"
+                      className="appearance-none bg-white/[0.04] text-white/70 text-sm border border-white/[0.08] rounded-lg px-3 py-2 focus:outline-none focus:border-white/20 focus:bg-white/[0.06] transition-all duration-200 cursor-pointer"
                     >
                       <option value="">All Components</option>
                       {components.map((c) => (
@@ -283,37 +301,39 @@ const ReleaseNotesRender = () => {
                   </div>
                   <button
                     onClick={handleExport}
-                    className="text-sm font-medium text-white/80 hover:text-white bg-[#231146]/60 border border-white/10 rounded-md px-4 py-1.5 hover:bg-[#231146] transition-colors"
+                    className="text-sm font-medium text-white/50 hover:text-white bg-white/[0.04] border border-white/[0.08] rounded-lg px-4 py-2 hover:bg-white/[0.08] hover:border-white/[0.14] transition-all duration-200"
                   >
                     Export CSV
                   </button>
                 </div>
 
                 {/* Table */}
-                <div className="overflow-x-auto rounded-b-2xl border border-t-0 border-white/10 bg-[#231146]/50 backdrop-blur-sm shadow-lg">
+                <div className="overflow-x-auto rounded-2xl border border-white/[0.08] bg-white/[0.02] backdrop-blur-xl">
                   <table
                     className="w-full text-left"
                     aria-label="Release Notes"
                   >
                     <thead>
-                      <tr className="bg-[#2B1A4F]/98 border-b-2 border-pink/40">
+                      <tr className="border-b border-white/[0.08]">
                         <th
-                          className="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider cursor-pointer select-none hover:text-pink transition-colors w-[120px]"
+                          className="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase cursor-pointer select-none hover:text-white/70 transition-colors duration-200 w-[100px]"
                           onClick={toggleSort}
                         >
                           Priority{" "}
-                          {sortDirection === "asc" ? "\u25B2" : "\u25BC"}
+                          <span className="text-white/20">
+                            {sortDirection === "asc" ? "\u25B2" : "\u25BC"}
+                          </span>
                         </th>
-                        <th className="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider w-[130px]">
+                        <th className="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase w-[120px]">
                           Type
                         </th>
-                        <th className="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider w-[170px]">
+                        <th className="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase w-[160px]">
                           Component
                         </th>
-                        <th className="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider w-[150px]">
+                        <th className="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase w-[130px]">
                           Issue
                         </th>
-                        <th className="px-4 py-3 text-white font-bold text-xs uppercase tracking-wider min-w-[300px]">
+                        <th className="px-5 py-3.5 text-white/40 font-medium text-xs tracking-wider uppercase min-w-[300px]">
                           Title
                         </th>
                       </tr>
@@ -323,19 +343,16 @@ const ReleaseNotesRender = () => {
                         <tr
                           key={row.id}
                           data-row
-                          className={`border-b border-white/5 transition-all duration-200 hover:bg-white/[0.08] hover:-translate-y-px hover:shadow-md ${
-                            idx % 2 === 0 ? "bg-white/[0.02]" : ""
+                          className={`border-b border-white/[0.04] transition-colors duration-150 hover:bg-white/[0.04] ${
+                            idx % 2 === 0 ? "" : "bg-white/[0.01]"
                           }`}
                         >
-                          <td
-                            data-field="priority"
-                            className="px-4 py-3 text-white/90"
-                          >
+                          <td data-field="priority" className="px-5 py-3.5">
                             <span
                               title={fetchTitle(
                                 (row.priority as string) || "6",
                               )}
-                              className={`badge bg-secondary priority-${row.priority}`}
+                              className={`badge priority-${row.priority}`}
                             >
                               {row.priority && row.priority !== "6"
                                 ? `P${row.priority}`
@@ -344,17 +361,17 @@ const ReleaseNotesRender = () => {
                           </td>
                           <td
                             data-field="type"
-                            className="px-4 py-3 text-white/90"
+                            className="px-5 py-3.5 text-white/60 text-sm"
                           >
                             {row.type || "Hidden"}
                           </td>
                           <td
                             data-field="component"
-                            className="px-4 py-3 text-white/90"
+                            className="px-5 py-3.5 text-white/60 text-sm"
                           >
                             {row.component || ""}
                           </td>
-                          <td data-field="id" className="px-4 py-3">
+                          <td data-field="id" className="px-5 py-3.5">
                             <a
                               target="_blank"
                               rel="noopener noreferrer"
@@ -366,7 +383,7 @@ const ReleaseNotesRender = () => {
                           </td>
                           <td
                             data-field="title"
-                            className="px-4 py-3 text-white/90 break-words"
+                            className="px-5 py-3.5 text-white/70 text-sm leading-relaxed break-words"
                           >
                             {row.title}
                           </td>
@@ -376,7 +393,7 @@ const ReleaseNotesRender = () => {
                         <tr>
                           <td
                             colSpan={5}
-                            className="px-4 py-8 text-center text-white/60"
+                            className="px-5 py-16 text-center text-white/30 text-sm"
                           >
                             No results found
                           </td>
@@ -387,16 +404,16 @@ const ReleaseNotesRender = () => {
                 </div>
 
                 {/* Pagination */}
-                <div className="flex items-center justify-between gap-4 mt-4 bg-[#231146]/30 rounded-lg border border-white/[0.08] p-3 shadow-md text-white/85">
-                  <div className="flex items-center gap-2 text-sm">
-                    <span>Rows per page:</span>
+                <div className="flex items-center justify-between gap-4 mt-4 px-1">
+                  <div className="flex items-center gap-2 text-sm text-white/40">
+                    <span>Rows</span>
                     <select
                       value={pageSize}
                       onChange={(e) => {
                         setPageSize(Number(e.target.value));
                         setPage(0);
                       }}
-                      className="bg-[#231146]/60 text-white/85 border border-white/10 rounded-md px-2 py-1 text-sm focus:outline-none focus:border-pink"
+                      className="appearance-none bg-white/[0.04] text-white/60 border border-white/[0.08] rounded-lg px-2 py-1 text-sm focus:outline-none focus:border-white/20 transition-all duration-200 cursor-pointer"
                     >
                       {[20, 50, 75].map((size) => (
                         <option key={size} value={size}>
@@ -405,28 +422,30 @@ const ReleaseNotesRender = () => {
                       ))}
                     </select>
                   </div>
-                  <div className="flex items-center gap-3 text-sm">
+                  <div className="flex items-center gap-4 text-sm text-white/40">
                     <span>
                       {totalRows > 0
                         ? `${safePage * pageSize + 1}\u2013${Math.min((safePage + 1) * pageSize, totalRows)} of ${totalRows}`
                         : "0 of 0"}
                     </span>
-                    <button
-                      onClick={() => setPage((p) => Math.max(0, p - 1))}
-                      disabled={safePage === 0}
-                      className="px-2 py-1 rounded bg-[#231146]/40 border border-white/5 hover:bg-pink/15 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
-                    >
-                      &lsaquo;
-                    </button>
-                    <button
-                      onClick={() =>
-                        setPage((p) => Math.min(totalPages - 1, p + 1))
-                      }
-                      disabled={safePage >= totalPages - 1}
-                      className="px-2 py-1 rounded bg-[#231146]/40 border border-white/5 hover:bg-pink/15 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
-                    >
-                      &rsaquo;
-                    </button>
+                    <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => setPage((p) => Math.max(0, p - 1))}
+                        disabled={safePage === 0}
+                        className="w-8 h-8 flex items-center justify-center rounded-lg bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.08] disabled:opacity-25 disabled:cursor-not-allowed transition-all duration-200 text-white/60"
+                      >
+                        &lsaquo;
+                      </button>
+                      <button
+                        onClick={() =>
+                          setPage((p) => Math.min(totalPages - 1, p + 1))
+                        }
+                        disabled={safePage >= totalPages - 1}
+                        className="w-8 h-8 flex items-center justify-center rounded-lg bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.08] disabled:opacity-25 disabled:cursor-not-allowed transition-all duration-200 text-white/60"
+                      >
+                        &rsaquo;
+                      </button>
+                    </div>
                   </div>
                 </div>
               </>

--- a/src/components/Content/ReleaseNotesVersionSelector/__tests__/ReleaseNotesVersionSelector.test.tsx
+++ b/src/components/Content/ReleaseNotesVersionSelector/__tests__/ReleaseNotesVersionSelector.test.tsx
@@ -46,7 +46,8 @@ describe("ReleaseNotesVersionSelector", () => {
         availableLTSVersions={[21]}
       />,
     );
-    fireEvent.click(getAllByRole("button")[0]); // JDK 22 (non-LTS)
+    // LTS versions render first, so JDK 21 is button[0], JDK 22 is button[1]
+    fireEvent.click(getAllByRole("button")[1]); // JDK 22 (non-LTS)
     expect(mockPush).toHaveBeenCalledWith("?version=22");
   });
 
@@ -58,17 +59,25 @@ describe("ReleaseNotesVersionSelector", () => {
       />,
     );
     const buttons = container.querySelectorAll("button");
-    // JDK 21 (LTS) should have LTS badge text
-    expect(buttons[1].textContent).toContain("LTS");
-    // JDK 22 (non-LTS)
-    expect(buttons[0].textContent).toContain("Non-LTS");
+    // LTS versions render first: JDK 21 (LTS) is button[0]
+    expect(buttons[0].textContent).toContain("Long Term Support");
+    // JDK 22 (non-LTS) is button[1] and should not contain LTS text
+    expect(buttons[1].textContent).not.toContain("Long Term Support");
   });
 
-  it("renders legend for LTS and non-LTS", () => {
-    const { getByText } = render(
-      <ReleaseNotesVersionSelector {...defaultProps} />,
+  it("renders section headers for LTS", () => {
+    const { container } = render(
+      <ReleaseNotesVersionSelector
+        availableVersions={[22, 21]}
+        availableLTSVersions={[21]}
+      />,
     );
-    expect(getByText("LTS Version")).toBeTruthy();
-    expect(getByText("Non-LTS Version")).toBeTruthy();
+    // LTS badge in the section header
+    const ltsBadge = container.querySelector(".text-pink.uppercase");
+    expect(ltsBadge?.textContent).toBe("LTS");
+    // Feature Releases section header for non-LTS
+    const headers = container.querySelectorAll("h3");
+    const texts = Array.from(headers).map((h) => h.textContent);
+    expect(texts).toContain("Feature Releases");
   });
 });

--- a/src/components/Content/ReleaseNotesVersionSelector/index.tsx
+++ b/src/components/Content/ReleaseNotesVersionSelector/index.tsx
@@ -1,77 +1,126 @@
-"use client"
+"use client";
 
-import React from "react"
-import { useTranslations } from "next-intl"
-import { useRouter } from "next/navigation"
+import React from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
 
 interface ReleaseNotesVersionSelectorProps {
-    availableVersions: number[]
-    availableLTSVersions: number[]
+  availableVersions: number[];
+  availableLTSVersions: number[];
 }
 
-const ReleaseNotesVersionSelector: React.FC<ReleaseNotesVersionSelectorProps> = ({
-    availableVersions,
-    availableLTSVersions
-}) => {
-    const t = useTranslations("ReleaseNotes")
-    const router = useRouter()
+const ReleaseNotesVersionSelector: React.FC<
+  ReleaseNotesVersionSelectorProps
+> = ({ availableVersions, availableLTSVersions }) => {
+  const t = useTranslations("ReleaseNotes");
+  const router = useRouter();
 
-    const handleVersionSelect = (version: number) => {
-        // Navigate to the release notes page with the selected version
-        router.push(`?version=${version}`)
-    }
+  const handleVersionSelect = (version: number) => {
+    router.push(`?version=${version}`);
+  };
 
-    return (
-        <div className="release-notes-version-selector max-w-6xl mx-auto p-6 lg:px-0">
-            <div className="bg-gradient-to-br from-[#200E46]/90 to-[#2B1A4F]/90 rounded-3xl border border-white/20 shadow-lg p-8">
-                <h2 className="text-2xl font-bold text-white mb-4 text-center">
-                    {t('selectVersion')}
-                </h2>
-                <p className="text-white/80 text-center mb-8">
-                    {t('selectVersionDescription')}
-                </p>
+  const ltsVersions = availableVersions.filter((v) =>
+    availableLTSVersions.includes(v),
+  );
+  const nonLtsVersions = availableVersions.filter(
+    (v) => !availableLTSVersions.includes(v),
+  );
 
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-                    {availableVersions.map((version) => {
-                        const isLTS = availableLTSVersions.includes(version)
-                        return (
-                            <button
-                                key={version}
-                                onClick={() => handleVersionSelect(version)}
-                                className={`${isLTS
-                                    ? 'bg-purple hover:bg-pink border-pink/50'
-                                    : 'bg-blue hover:bg-purple border-white/20'
-                                    } transition-colors duration-200 rounded-lg p-4 border hover:border-pink text-center group`}
-                            >
-                                <div className="text-white text-xl font-bold mb-1">
-                                    JDK {version}
-                                </div>
-                                <div className={`text-xs mb-2 ${isLTS ? 'text-pink' : 'text-grey'}`}>
-                                    {isLTS ? 'LTS' : 'Non-LTS'}
-                                </div>
-                                <div className="text-pink text-xs opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                                    {t('viewReleaseNotes')}
-                                </div>
-                            </button>
-                        )
-                    })}
+  return (
+    <div className="max-w-4xl mx-auto px-6 pb-20 pt-4">
+      {/* Section: LTS */}
+      {ltsVersions.length > 0 && (
+        <div className="mb-16">
+          <div className="flex items-center gap-3 mb-8">
+            <h3 className="text-sm font-semibold tracking-[0.2em] uppercase text-white/50">
+              {t("selectVersion")}
+            </h3>
+            <span className="inline-flex items-center rounded-full bg-pink/15 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-pink uppercase">
+              LTS
+            </span>
+            <div className="flex-1 h-px bg-gradient-to-r from-white/10 to-transparent" />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {ltsVersions.map((version) => (
+              <button
+                key={version}
+                onClick={() => handleVersionSelect(version)}
+                className="group relative rounded-2xl bg-white/[0.04] backdrop-blur-xl border border-white/[0.08] p-6 text-left transition-all duration-300 hover:bg-white/[0.08] hover:border-white/[0.16] hover:shadow-[0_8px_40px_rgba(255,19,101,0.08)] hover:scale-[1.02] active:scale-[0.98]"
+              >
+                <div className="flex items-baseline justify-between mb-3">
+                  <span className="text-[28px] font-semibold tracking-tight text-white">
+                    JDK {version}
+                  </span>
+                  <span className="text-[11px] font-medium tracking-wider uppercase text-pink/80">
+                    Long Term Support
+                  </span>
                 </div>
-
-                <div className="mt-8 text-center">
-                    <div className="flex justify-center gap-6 text-sm">
-                        <div className="flex items-center gap-2">
-                            <div className="w-3 h-3 bg-purple rounded border border-pink/50"></div>
-                            <span className="text-white/80">LTS Version</span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                            <div className="w-3 h-3 bg-blue rounded border border-white/20"></div>
-                            <span className="text-white/80">Non-LTS Version</span>
-                        </div>
-                    </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-white/40 group-hover:text-white/60 transition-colors duration-300">
+                    {t("viewReleaseNotes")}
+                  </span>
+                  <svg
+                    className="w-4 h-4 text-white/20 group-hover:text-pink group-hover:translate-x-1 transition-all duration-300"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
                 </div>
-            </div>
+                <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-pink/[0.04] to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
+              </button>
+            ))}
+          </div>
         </div>
-    )
-}
+      )}
 
-export default ReleaseNotesVersionSelector
+      {/* Section: Non-LTS */}
+      {nonLtsVersions.length > 0 && (
+        <div>
+          <div className="flex items-center gap-3 mb-8">
+            <h3 className="text-sm font-semibold tracking-[0.2em] uppercase text-white/50">
+              Feature Releases
+            </h3>
+            <div className="flex-1 h-px bg-gradient-to-r from-white/10 to-transparent" />
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            {nonLtsVersions.map((version) => (
+              <button
+                key={version}
+                onClick={() => handleVersionSelect(version)}
+                className="group relative rounded-xl bg-white/[0.03] backdrop-blur-xl border border-white/[0.06] px-5 py-4 text-left transition-all duration-300 hover:bg-white/[0.07] hover:border-white/[0.14] hover:scale-[1.02] active:scale-[0.98]"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-lg font-medium tracking-tight text-white/80 group-hover:text-white transition-colors duration-300">
+                    JDK {version}
+                  </span>
+                  <svg
+                    className="w-3.5 h-3.5 text-white/15 group-hover:text-white/40 group-hover:translate-x-0.5 transition-all duration-300"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ReleaseNotesVersionSelector;


### PR DESCRIPTION
## Summary

Redesigns the `/temurin/release-notes` page with a cleaner, more modern aesthetic.

### Changes

**ReleaseNotesVersionSelector**
- Split LTS and non-LTS versions into separate, clearly labeled sections
- LTS versions get larger cards with "Long Term Support" labels and hover arrows
- Non-LTS versions shown in a compact grid under "Feature Releases"
- Frosted glass card styling with subtle hover effects

**ReleaseNotes table**
- Cleaner version title typography
- Refined filter toolbar with better spacing
- Improved table with subtle row styling
- Simplified pagination controls
- P1 fix count shown as an inline pill instead of a paragraph
- Better loading spinner with text label

**Tests**
- Updated ReleaseNotesVersionSelector tests for new section-based layout
- Updated snapshots