### PR TITLE
Change JRE installation command to headless version

### DIFF
--- a/content/blog/eclipse-temurin-26-available/index.md
+++ b/content/blog/eclipse-temurin-26-available/index.md
@@ -24,7 +24,7 @@ This release contains the following fixes and updates:
 For server environments where no graphical components are required, a new headless JRE package is also available. This excludes GUI-related libraries such as AWT and reduces the overall installation footprint.
 
 ```bash
-sudo dnf install temurin-26-jre
+sudo dnf install temurin-26-jre-headless
 ```
 
 ### Coexistenance of JDK & JRE (via RPM installation) Is Now Prevented


### PR DESCRIPTION
Updated installation command to use headless JRE package for Eclipse Temurin 26.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` and `npm run build` passes
