### PR TITLE
Correct CDXA checksum case-sensitivity matching

### DIFF
--- a/src/components/Temurin/Releases/ReleaseResults/__tests__/ReleaseResults.test.tsx
+++ b/src/components/Temurin/Releases/ReleaseResults/__tests__/ReleaseResults.test.tsx
@@ -644,8 +644,8 @@ describe("ReleaseResults component", () => {
   it("should render attestation icon when attestation exists for checksum", () => {
     vi.mocked(useAttestations).mockReturnValue({
       attestations: {
-        abc123: {
-          target_checksum: "abc123",
+        ABC123: {
+          target_checksum: "ABC123",
         } as Cdxa,
       },
       isLoading: false,
@@ -668,7 +668,7 @@ describe("ReleaseResults component", () => {
   it("should NOT render attestation icon when attestation is explicitly absent", () => {
     vi.mocked(useAttestations).mockReturnValue({
       attestations: {
-        abc123: undefined, // resolved, but no attestation
+        ABC123: undefined, // resolved, but no attestation
       },
       isLoading: false,
       error: undefined,

--- a/src/components/Temurin/Releases/ReleaseResults/index.tsx
+++ b/src/components/Temurin/Releases/ReleaseResults/index.tsx
@@ -75,7 +75,11 @@ const ReleaseResults: React.FC<ReleaseResultsProps> = ({
 
   const hasAttestation = (checksum?: string | null): boolean => {
     if (attestationsLoading || !checksum) return false;
-    return attestations[checksum] !== undefined;
+
+    // Normalize checksum to uppercase for case-insensitive matching
+    const normalizedChecksum = checksum.toUpperCase();
+
+    return attestations[normalizedChecksum] !== undefined;
   };
 
   if (isLoading) {

--- a/src/hooks/__tests__/useAttestation.test.ts
+++ b/src/hooks/__tests__/useAttestation.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 
 const mockAttestations = [
   {
-    target_checksum: "checksum-1",
+    target_checksum: "CHECKSUM-1",
     predicate_type: "https://slsa.dev/provenance/v1",
   },
 ];
@@ -30,7 +30,7 @@ it("does not fetch when releaseName is undefined", async () => {
 //Test 2 fetch and normalize
 it("fetches attestations and normalizes by checksum", async () => {
   mockedFetchCdxas.mockResolvedValue([
-    { target_checksum: "checksum-1" },
+    { target_checksum: "CHECKSUM-1" },
   ] as any);
 
   const { result } = renderHook(() =>
@@ -41,7 +41,7 @@ it("fetches attestations and normalizes by checksum", async () => {
     expect(result.current.isLoading).toBe(false);
   });
 
-  expect(result.current.attestations["checksum-1"]).toBeDefined();
+  expect(result.current.attestations["CHECKSUM-1"]).toBeDefined();
 });
 
 // Test 3 partial matches
@@ -58,8 +58,8 @@ it("sets undefined for checksums not returned by the API", async () => {
     expect(result.current.isLoading).toBe(false);
   });
 
-  expect(result.current.attestations["checksum-1"]).toBeDefined();
-  expect(result.current.attestations["checksum-2"]).toBeUndefined();
+  expect(result.current.attestations["CHECKSUM-1"]).toBeDefined();
+  expect(result.current.attestations["CHECKSUM-2"]).toBeUndefined();
 });
 
 //Test 4 404 is NOT an error
@@ -76,7 +76,7 @@ it("handles 404 responses by caching undefined attestations", async () => {
   });
 
   expect(result.current.error).toBeUndefined();
-  expect(result.current.attestations["checksum-1"]).toBeUndefined();
+  expect(result.current.attestations["CHECKSUM-1"]).toBeUndefined();
 });
 
 //Test 5 non-404 error surfaces
@@ -95,13 +95,13 @@ it("exposes error for non-404 failures", async () => {
 //Test 6 caching prevents refetch
 it("does not refetch attestations for cached checksums", async () => {
   mockedFetchCdxas.mockResolvedValue([
-    { target_checksum: "checksum-1" },
+    { target_checksum: "CHECKSUM-1" },
   ] as any);
 
   const { rerender } = renderHook(
     ({ checksums }) => useAttestations("release_name_mock", checksums),
     {
-      initialProps: { checksums: ["checksum-1"] },
+      initialProps: { checksums: ["CHECKSUM-1"] },
     },
   );
 
@@ -113,7 +113,7 @@ it("does not refetch attestations for cached checksums", async () => {
   const callsAfterFirstFetch = mockedFetchCdxas.mock.calls.length;
 
   // Rerender with the same checksum
-  rerender({ checksums: ["checksum-1"] });
+  rerender({ checksums: ["CHECKSUM-1"] });
 
   // Allow effects to flush
   await new Promise((r) => setTimeout(r, 0));

--- a/src/hooks/__tests__/useAttestations.test.ts
+++ b/src/hooks/__tests__/useAttestations.test.ts
@@ -32,8 +32,8 @@ describe("useAttestations", () => {
 
   it("fetches attestations for a valid release", async () => {
     const mockAttestations = [
-      { target_checksum: "abc123", statement: "test-statement-1" },
-      { target_checksum: "def456", statement: "test-statement-2" },
+      { target_checksum: "ABC123", statement: "test-statement-1" },
+      { target_checksum: "DEF456", statement: "test-statement-2" },
     ];
 
     mockedFetchCdxas.mockResolvedValue(mockAttestations as any);
@@ -48,8 +48,8 @@ describe("useAttestations", () => {
 
     expect(mockedFetchCdxas).toHaveBeenCalledWith("jdk-21+35");
 
-    expect(result.current.attestations["abc123"]).toEqual(mockAttestations[0]);
-    expect(result.current.attestations["def456"]).toEqual(mockAttestations[1]);
+    expect(result.current.attestations["ABC123"]).toEqual(mockAttestations[0]);
+    expect(result.current.attestations["DEF456"]).toEqual(mockAttestations[1]);
   });
 
   it("handles 404 error by caching undefined for checksums", async () => {

--- a/src/hooks/useAttestations.ts
+++ b/src/hooks/useAttestations.ts
@@ -112,7 +112,9 @@ export function useAttestations(
                 ?.response?.status ?? (err as { status?: number })?.status);
         if (status === 404) {
           unresolvedChecksums.forEach((checksum) => {
-            cacheRef.current[checksum] = undefined;
+            // Normalize checksum to uppercase for case-insensitive matching
+            const normalizedChecksum = checksum.toUpperCase();
+            cacheRef.current[normalizedChecksum] = undefined;
           });
         } else {
           setError(err instanceof Error ? err : new Error(String(err)));

--- a/src/hooks/useAttestations.ts
+++ b/src/hooks/useAttestations.ts
@@ -88,12 +88,16 @@ export function useAttestations(
 
         for (const cdxa of cdxas) {
           if (cdxa.target_checksum) {
-            cdxaMap[cdxa.target_checksum] = cdxa;
+            // Normalize checksum to uppercase for case-insensitive matching
+            const normalizedChecksum = cdxa.target_checksum.toUpperCase();
+            cdxaMap[normalizedChecksum] = cdxa;
           }
         }
 
         unresolvedChecksums.forEach((checksum) => {
-          cacheRef.current[checksum] = cdxaMap[checksum] ?? undefined;
+          // Normalize checksum to uppercase for case-insensitive matching
+          const normalizedChecksum = checksum.toUpperCase();
+          cacheRef.current[normalizedChecksum] = cdxaMap[normalizedChecksum] ?? undefined;
         });
       } catch (err: unknown) {
         if (cancelled) return;


### PR DESCRIPTION
# Description of change

Fixes https://github.com/adoptium/adoptium.net/issues/1073

Adds upper-casing of queried CDXA target_checksum, and upper-cased the Binary.checksum when matching the downloaded CDXAMap[] array.

Assisted-by: IBM Bob 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
