### PR TITLE
Addendum to the July 2026 release blog

### DIFF
--- a/content/blog/eclipse-temurin-8u502-11032-17020-21012-2504-2602-available/index.md
+++ b/content/blog/eclipse-temurin-8u502-11032-17020-21012-2504-2602-available/index.md
@@ -52,3 +52,7 @@ Several improvements have been made to the reproducible-build verification tooli
 ### Build Reliability: Boot JDK Download Retry Logic
 
 The build tooling now retries failed `curl` commands when downloading the boot JDK. This reduces transient build failures caused by temporary network issues in CI environments, improving overall release reliability.
+
+### Linux arm32 Not Included for JDK 8
+
+Eclipse Temurin will not be shipping a JDK 8 build for Linux Arm32 during this release cycle due to concerns raised during the quality assurance process. We hope to resolve these concerns as soon as possible.


### PR DESCRIPTION
# Description of change

Adding to the July 2026 release notes to cover the exclusion of jdk8 arm32 from the released platforms.

## Checklist

- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
