### PR TITLE
fix: correct 'plese' to 'please' typo in contributing guide

### DIFF
--- a/content/asciidoc-pages/contributing/index.adoc
+++ b/content/asciidoc-pages/contributing/index.adoc
@@ -69,7 +69,7 @@ git checkout -b my_new_branch
 git remote add upstream https://github.com/adoptium/aqa-tests.git
 ----
 
-Before you start working on the issue, plese make sure the local branch is up to date:
+Before you start working on the issue, please make sure the local branch is up to date:
 
 [source, bash]
 ----


### PR DESCRIPTION
Hi @gdams! This PR replaces the closed #1258 (which you approved) — same typo fix: 'plese' → 'please' in the contributing guide. I noticed the eclipsefdn/eca check is failing; that may need your attention as the maintainer. Let me know if anything else needs changing!