### PR TITLE
[issue-1244] Fix typo never merged

### DIFF
--- a/content/asciidoc-pages/contributing/index.adoc
+++ b/content/asciidoc-pages/contributing/index.adoc
@@ -69,7 +69,7 @@ git checkout -b my_new_branch
 git remote add upstream https://github.com/adoptium/aqa-tests.git
 ----
 
-Before you start working on the issue, plese make sure the local branch is up to date:
+Before you start working on the issue, please make sure the local branch is up to date:
 
 [source, bash]
 ----


### PR DESCRIPTION
# Description of change

Fix typo from issue #1244 that was never merged.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` and `npm run build` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
